### PR TITLE
Updates scrolling to use react-router-scroll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ before_install:
 - cp .env.example .env
 script:
 - npm test
-- rvm use ruby-head
+- rvm install 2.3.1
+- rvm use 2.3.1
 - gem install danger
 - danger
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
-rvm:
-- 2.3.1
 before_install:
 - cp .env.example .env
 script:
 - npm test
+- rvm use 2.3.1
 - gem install danger
 - danger
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
 - cp .env.example .env
 script:
 - npm test
-- rvm use 2.3.1
+- rvm use ruby-head
 - gem install danger
 - danger
 notifications:

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "react-redux": "4.4.5",
     "react-router": "2.7.0",
     "react-router-redux": "4.0.5",
+    "react-router-scroll": "0.3.2",
     "redux": "3.5.2",
     "redux-logger": "2.6.1",
     "redux-persist": "3.5.0",

--- a/src/components/viewport/ScrollComponent.js
+++ b/src/components/viewport/ScrollComponent.js
@@ -3,10 +3,6 @@ let lastScrollDirection = null
 let lastScrollY = null
 let ticking = false
 const scrollObjects = []
-const scrollTargetObjects = []
-
-// SHARED METHODS
-// -------------------------------------
 
 function callMethod(component, method, scrollProperties) {
   if (component[method]) {
@@ -47,9 +43,6 @@ function getScrollAction(scrollProperties) {
   }
   return null
 }
-
-// SCROLLING THE WINDOW
-// -------------------------------------
 
 function getScrollY() {
   return Math.ceil(window.pageYOffset)
@@ -117,69 +110,6 @@ export function removeScrollObject(obj) {
   if (scrollObjects.length === 0) {
     hasWindowListener = false
     window.removeEventListener('scroll', windowWasScrolled)
-  }
-}
-
-// SCROLLING AN ELEMENT
-// -------------------------------------
-
-function getTargetScrollY(el) {
-  return Math.ceil(el.scrollTop)
-}
-
-function getTargetScrollHeight(el) {
-  return Math.max(el.scrollHeight, el.offsetHeight)
-}
-
-function getTargetScrollBottom(scrollHeight, el) {
-  return Math.round(scrollHeight - el.offsetHeight)
-}
-
-function getTargetScrollProperties(el) {
-  const scrollY = getTargetScrollY(el)
-  const scrollHeight = getTargetScrollHeight(el)
-  const scrollBottom = getTargetScrollBottom(scrollHeight, el)
-  return {
-    scrollY,
-    scrollHeight,
-    scrollBottom,
-    scrollPercent: getScrollPercent(0, scrollBottom, scrollY),
-  }
-}
-
-function targetScrolled() {
-  for (const obj of scrollTargetObjects) {
-    const scrollProperties = getTargetScrollProperties(obj.element)
-    const scrollAction = getScrollAction(scrollProperties)
-    callMethod(obj.component, 'onScrollTarget', scrollProperties)
-    if (scrollAction) {
-      callMethod(obj.component, `${scrollAction}Target`, scrollProperties)
-    }
-  }
-}
-
-function targetWasScrolled() {
-  if (!ticking) {
-    requestAnimationFrame(() => {
-      targetScrolled()
-      ticking = false
-    })
-    ticking = true
-  }
-}
-
-export function addScrollTarget(obj) {
-  if (scrollTargetObjects.indexOf(obj) === -1) {
-    scrollTargetObjects.push(obj)
-    obj.element.addEventListener('scroll', targetWasScrolled)
-  }
-}
-
-export function removeScrollTarget(obj) {
-  const index = scrollTargetObjects.indexOf(obj)
-  if (index > -1) {
-    scrollTargetObjects.splice(index, 1)
-    obj.element.removeEventListener('scroll', targetWasScrolled)
   }
 }
 

--- a/src/containers/StreamContainer.js
+++ b/src/containers/StreamContainer.js
@@ -1,13 +1,10 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
-import { browserHistory } from 'react-router'
 import shallowCompare from 'react-addons-shallow-compare'
 import { debounce, get } from 'lodash'
 import classNames from 'classnames'
-import scrollTop from '../vendor/scrolling'
 import { runningFetches } from '../sagas/requester'
 import * as ACTION_TYPES from '../constants/action_types'
-import { SESSION_KEYS } from '../constants/application_types'
 import {
   selectColumnCount,
   selectHistory,
@@ -17,12 +14,7 @@ import {
 } from '../selectors/gui'
 import { selectPathname } from '../selectors/routing'
 import { findModel } from '../helpers/json_helper'
-import {
-  addScrollObject,
-  addScrollTarget,
-  removeScrollObject,
-  removeScrollTarget,
-} from '../components/viewport/ScrollComponent'
+import { addScrollObject, removeScrollObject } from '../components/viewport/ScrollComponent'
 import { ElloMark } from '../components/svg/ElloIcons'
 import { Paginator } from '../components/streams/Paginator'
 import { ErrorState4xx } from '../components/errors/Errors'
@@ -59,7 +51,6 @@ class StreamContainer extends Component {
     columnCount: PropTypes.number,
     dispatch: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
-    ignoresScrollPosition: PropTypes.bool.isRequired,
     initModel: PropTypes.object,
     innerHeight: PropTypes.number,
     innerWidth: PropTypes.number,
@@ -73,71 +64,39 @@ class StreamContainer extends Component {
     result: PropTypes.object.isRequired,
     resultPath: PropTypes.string,
     routerState: PropTypes.object,
-    scrollContainer: PropTypes.object,
-    scrollSessionKey: PropTypes.string,
     stream: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
     paginatorText: 'Loading',
-    ignoresScrollPosition: false,
     isModalComponent: false,
   }
 
   componentWillMount() {
-    const { action, dispatch, omnibar, pathname } = this.props
+    const { action, dispatch, omnibar } = this.props
     if (typeof window !== 'undefined' && action) {
       dispatch(action)
     }
 
-    let browserListen
-    if (browserHistory) {
-      browserListen = browserHistory.listen
-    } else {
-      browserListen = (listener) => {
-        listener({ key: 'testing' })
-        return () => null
-      }
-    }
-    const unlisten = browserListen(location => {
-      this.state = { action, locationKey: /\/search/.test(pathname) ? '/search' : location.key }
-    })
-    unlisten()
-    this.setScroll = debounce(this.setScroll, 300)
-    this.setScrollTarget = debounce(this.setScrollTarget, 300)
-    this.shouldScroll = true
+    this.state = { action }
     this.wasOmnibarActive = omnibar.isActive
+    this.setScroll = debounce(this.setScroll, 333)
   }
 
   componentDidMount() {
-    const { isModalComponent, routerState, scrollContainer } = this.props
     if (window.embetter) {
       window.embetter.reloadPlayers()
     }
-    if (isModalComponent && scrollContainer) {
-      this.scrollObject = { component: this, element: scrollContainer }
-      addScrollTarget(this.scrollObject)
-    } else if (!isModalComponent) {
+    const { isModalComponent } = this.props
+    if (!isModalComponent) {
       this.scrollObject = this
       addScrollObject(this.scrollObject)
     }
-
-    const shouldScrollToTop = true
-    if (routerState.didComeFromSeeMoreCommentsLink) {
-      this.saveScroll = false
-    } else {
-      this.saveScroll = true
-    }
-    this.attemptToRestoreScroll(shouldScrollToTop)
   }
 
   componentWillReceiveProps(nextProps) {
     const { stream } = nextProps
     const { action } = this.state
-    if (this.props.isModalComponent && !this.props.scrollContainer && nextProps.scrollContainer) {
-      this.scrollObject = { component: this, element: nextProps.scrollContainer }
-      addScrollTarget(this.scrollObject)
-    }
     if (!action) { return }
     if (stream.type === ACTION_TYPES.LOAD_NEXT_CONTENT_SUCCESS) {
       this.setState({ hidePaginator: true })
@@ -177,19 +136,7 @@ class StreamContainer extends Component {
     if (window.embetter) {
       window.embetter.reloadPlayers()
     }
-
-    const { action } = this.state
-    const { innerHeight, stream, omnibar } = this.props
-    const canScroll = document.body.scrollHeight > innerHeight
-    const shouldScroll = this.shouldScroll && (canScroll ||
-      (stream.type === ACTION_TYPES.LOAD_STREAM_SUCCESS &&
-       action && action.payload &&
-       stream.payload.endpoint.path === action.payload.endpoint.path))
-    if (shouldScroll) {
-      if (this.attemptToRestoreScroll()) {
-        this.shouldScroll = false
-      }
-    }
+    const { omnibar } = this.props
     this.wasOmnibarActive = omnibar.isActive
   }
 
@@ -198,16 +145,10 @@ class StreamContainer extends Component {
       window.embetter.stopPlayers()
     }
     removeScrollObject(this.scrollObject)
-    removeScrollTarget(this.scrollObject)
-    this.saveScroll = false
   }
 
   onScroll() {
     this.setScroll()
-  }
-
-  onScrollTarget() {
-    this.setScrollTarget()
   }
 
   onScrollBottom() {
@@ -231,77 +172,10 @@ class StreamContainer extends Component {
   }
 
   setScroll() {
-    if (!this.saveScroll) { return }
-    const { dispatch } = this.props
-    const scrollTopValue = scrollTop(window)
-
-    dispatch({
-      type: ACTION_TYPES.GUI.SET_SCROLL,
-      payload: {
-        key: this.state.locationKey,
-        scrollTop: scrollTopValue,
-      },
-    })
-  }
-
-  setScrollTarget() {
-    if (!this.saveScroll) { return }
-    const { scrollContainer, scrollSessionKey } = this.props
-    let scrollTopValue
-    if (scrollContainer) {
-      scrollTopValue = scrollTop(scrollContainer)
+    const { pathname } = this.props
+    if (/\/notifications\b/.test(pathname)) {
+      Session.setItem(`${pathname}/scrollY`, window.scrollY)
     }
-    if (scrollSessionKey) {
-      const sessionStorageKey = SESSION_KEYS.scrollLocationKey(scrollSessionKey)
-      Session.setItem(sessionStorageKey, scrollTopValue)
-    }
-  }
-
-  attemptToRestoreScroll(fromMount = false) {
-    const { innerHeight, history, routerState, scrollContainer, isModalComponent } = this.props
-    let scrollTopValue = null
-    if (!routerState.didComeFromSeeMoreCommentsLink && !this.props.ignoresScrollPosition) {
-      if (fromMount && !isModalComponent) {
-        window.scrollTo(0, 0)
-        return false
-      }
-
-      this.saveScroll = true
-
-      let sessionScrollLocation = null
-      if (this.props.scrollSessionKey) {
-        const sessionStorageKey = SESSION_KEYS.scrollLocationKey(this.props.scrollSessionKey)
-        sessionScrollLocation = parseInt(Session.getItem(sessionStorageKey), 10)
-      }
-
-      if (sessionScrollLocation !== null) {
-        scrollTopValue = sessionScrollLocation
-      } else if (history[this.state.locationKey]) {
-        const historyObj = history[this.state.locationKey]
-        scrollTopValue = historyObj.scrollTop
-      }
-    } else if (routerState.didComeFromSeeMoreCommentsLink) {
-      this.saveScroll = true
-      scrollTopValue = document.body.scrollHeight - innerHeight
-    }
-
-    if (scrollTopValue) {
-      requestAnimationFrame(() => {
-        if (!this.saveScroll) {
-          return
-        }
-
-        if (isModalComponent) {
-          if (scrollContainer) {
-            scrollContainer.scrollTop = scrollTopValue
-          }
-        } else if (typeof window !== 'undefined') {
-          window.scrollTo(0, scrollTopValue)
-        }
-      })
-      return true
-    }
-    return false
   }
 
   loadPage(rel) {

--- a/src/containers/notifications/NotificationsContainer.js
+++ b/src/containers/notifications/NotificationsContainer.js
@@ -159,7 +159,7 @@ class NotificationsContainer extends Component {
             action={streamAction}
             className="isFullWidth"
             isModalComponent
-            key={`notificationView_${activeTabType}`}
+            key={`notificationView_${activeTabType}_${isReloading}`}
           />
         </div>
       </div>

--- a/src/containers/notifications/NotificationsContainer.js
+++ b/src/containers/notifications/NotificationsContainer.js
@@ -15,6 +15,7 @@ import {
 } from '../../components/notifications/NotificationIcons'
 import { TabListButtons } from '../../components/tabs/TabList'
 import { Paginator } from '../../components/streams/Paginator'
+import Session from '../../vendor/session'
 
 function mapStateToProps(state) {
   const activeTabType = selectActiveNotificationsType(state)
@@ -54,8 +55,14 @@ class NotificationsContainer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.activeTabType !== this.props.activeTabType && this.scrollContainer) {
-      this.scrollContainer.scrollTop = 0
+    const { activeTabType } = this.props
+    if (this.scrollContainer && prevProps.activeTabType !== activeTabType) {
+      const scrollY = Session.getItem(`/notifications/${activeTabType || 'all'}/scrollY`)
+      if (scrollY) {
+        this.scrollContainer.scrollTop = scrollY
+      } else {
+        this.scrollContainer.scrollTop = 0
+      }
     }
   }
 
@@ -83,6 +90,8 @@ class NotificationsContainer extends Component {
         payload: { activeTabType: type },
       })
     }
+    const pathname = `/notifications/${this.state.activeTabType || 'all'}`
+    Session.setItem(`${pathname}/scrollY`, this.scrollContainer.scrollTop)
     this.setState({ activeTabType: type })
   }
 
@@ -149,11 +158,8 @@ class NotificationsContainer extends Component {
           <StreamContainer
             action={streamAction}
             className="isFullWidth"
-            key={`notificationView_${activeTabType}`}
-            ref={(comp) => { this.streamContainer = comp }}
-            scrollContainer={this.scrollContainer}
-            scrollSessionKey={`notifications_${activeTabType}`}
             isModalComponent
+            key={`notificationView_${activeTabType}`}
           />
         </div>
       </div>

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -161,9 +161,6 @@ export const gui = (state = initialState, action = { type: '' }) => {
       return { ...state, lastFollowingBeaconVersion: action.payload.version }
     case GUI.SET_LAST_STARRED_BEACON_VERSION:
       return { ...state, lastStarredBeaconVersion: action.payload.version }
-    case GUI.SET_SCROLL:
-      newState.history[action.payload.key] = { ...action.payload }
-      return newState
     case GUI.SET_VIEWPORT_SIZE_ATTRIBUTES:
       return { ...state, ...action.payload }
     case GUI.TOGGLE_NOTIFICATIONS:

--- a/test/unit/containers/HeroContainer_test.js
+++ b/test/unit/containers/HeroContainer_test.js
@@ -85,12 +85,14 @@ describe('HeroContainer', () => {
   context('#selectBroadcast', () => {
     it('selects with memoization whether the current route has a broadcast message', () => {
       let state = {
+        authentication: { isLoggedIn: true },
         gui: { lastDiscoverBeaconVersion: null },
         routing: { location: { pathname: '/discover', change: false } },
       }
       expect(selectBroadcast(state)).to.equal(DISCOVER.BEACON_TEXT)
 
       state = {
+        authentication: { isLoggedIn: true },
         gui: { lastDiscoverBeaconVersion: null },
         routing: { location: { pathname: '/discover', change: true } },
       }
@@ -98,30 +100,35 @@ describe('HeroContainer', () => {
       expect(selectBroadcast.recomputations()).to.equal(1)
 
       state = {
+        authentication: { isLoggedIn: true },
         gui: { lastDiscoverBeaconVersion: '1' },
         routing: { location: { pathname: '/discover', change: true } },
       }
       expect(selectBroadcast(state)).to.equal(null)
 
       state = {
+        authentication: { isLoggedIn: true },
         gui: { lastFollowingBeaconVersion: null },
         routing: { location: { pathname: '/following', change: true } },
       }
       expect(selectBroadcast(state)).to.equal(FOLLOWING.BEACON_TEXT)
 
       state = {
+        authentication: { isLoggedIn: true },
         gui: { lastFollowingBeaconVersion: '1' },
         routing: { location: { pathname: '/following', change: true } },
       }
       expect(selectBroadcast(state)).to.equal(null)
 
       state = {
+        authentication: { isLoggedIn: true },
         gui: { lastStarredBeaconVersion: null },
         routing: { location: { pathname: '/starred', change: true } },
       }
       expect(selectBroadcast(state)).to.equal(STARRED.BEACON_TEXT)
 
       state = {
+        authentication: { isLoggedIn: true },
         gui: { lastStarredBeaconVersion: '1' },
         routing: { location: { pathname: '/starred', change: true } },
       }

--- a/test/unit/reducers/gui_test.js
+++ b/test/unit/reducers/gui_test.js
@@ -155,17 +155,6 @@ describe('gui reducer', () => {
       expect(reducer(undefined, action)).to.have.property('lastStarredBeaconVersion', '667')
     })
 
-    it('GUI.SET_SCROLL', () => {
-      const initialState = reducer(undefined, {})
-      expect(initialState.history).to.be.empty
-      const action1 = { type: GUI.SET_SCROLL, payload: { key: '1', scrollTop: 0 } }
-      const nextState = reducer(initialState, action1)
-      expect(nextState.history['1']).to.deep.equal(action1.payload)
-      const action2 = { type: GUI.SET_SCROLL, payload: { key: '2', scrollTop: 800 } }
-      const lastState = reducer(nextState, action2)
-      expect(lastState.history['2']).to.deep.equal({ ...action1.payload, ...action2.payload })
-    })
-
     it('GUI.SET_IS_NAVBAR_HIDDEN updates properties from the initialScrollState', () => {
       const initialState = reducer(undefined, {})
       expect(initialState).to.have.property('isNavbarHidden', false)


### PR DESCRIPTION
Stores notification scroll positions in `sessionStorage` to set scroll
position when changing between notification types. This works on mobile
as well even though there isn't really a way to click on other types of
notifications without scrolling to the top, but figured if we ever made
the notification tabs on mobile sticky that we wouldn't need to touch
the scrolling behavior.

[Finishes #129568023](https://www.pivotaltracker.com/story/show/129568023)