### PR TITLE
Fix Profile 2.0 UI issues

### DIFF
--- a/src/components/assets/BackgroundImage.css
+++ b/src/components/assets/BackgroundImage.css
@@ -63,7 +63,11 @@
   transition: background-color var(--speed) ease;
 }
 
-.BackgroundImage.hasOverlay::before {
+.BackgroundImage.hasOverlay4::before {
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.BackgroundImage.hasOverlay6::before {
   background-color: rgba(0, 0, 0, 0.6);
 }
 

--- a/src/components/heros/Hero.css
+++ b/src/components/heros/Hero.css
@@ -30,7 +30,7 @@
 }
 
 .ScrollToContentButton .ScrollToContentIcon {
-  margin-top: -4px;
+  margin-top: -2px;
 }
 
 .ScrollToContentButton .ScrollToContentIcon circle,

--- a/src/components/heros/Hero.js
+++ b/src/components/heros/Hero.js
@@ -30,7 +30,7 @@ UserDirtShareHeroButton.contextTypes = {
 const HeroProfile = ({ dpi, pathname, sources, userId, useGif }) =>
   <div className="HeroImage">
     <BackgroundImage
-      className="hasOverlay inHero"
+      className="hasOverlay6 inHero"
       sources={sources}
       dpi={dpi}
       useGif={useGif}

--- a/src/components/onboarding/OnboardingSettings.js
+++ b/src/components/onboarding/OnboardingSettings.js
@@ -30,7 +30,7 @@ const OnboardingSettings = (props, context) => {
           title="Upload Header"
         />
         <BackgroundImage
-          className="hasOverlay inOnboarding"
+          className="hasOverlay6 inOnboarding"
           sources={coverImage}
           useGif
         />

--- a/src/components/posts/PostHeader.css
+++ b/src/components/posts/PostHeader.css
@@ -104,6 +104,28 @@
   color: #535353;
 }
 
+/* Weird layout for reposts headers when in a UserDetail template */
+.RepostHeader.inUserDetail > .RepostHeaderReposter {
+  position: absolute;
+  top: 32px;
+  left: -40px;
+  z-index: 2;
+}
+
+.RepostHeader.inUserDetail > .RepostHeaderReposter .DraggableUsername {
+  display: none;
+}
+
+.RepostHeader.inUserDetail > .CategoryHeaderAuthor,
+.RepostHeader.inUserDetail > .RepostHeaderAuthor {
+  padding-left: 65px;
+  line-height: 60px;
+}
+
+.RepostHeader.inUserDetail .Avatar {
+  left: 25px;
+}
+
 /* MIN WIDTH!!! */
 @media (--break-2) {
   .PostHeader,
@@ -139,6 +161,18 @@
   .PostHeaderTimeAgoLink {
     top: 30px;
   }
+
+  .RepostHeader.inUserDetail > .CategoryHeaderAuthor,
+  .RepostHeader.inUserDetail > .RepostHeaderAuthor {
+    padding-left: 75px;
+    line-height: 80px;
+  }
+
+  .RepostHeader.inUserDetail > .RepostHeaderReposter {
+    top: 52px;
+    left: -60px;
+  }
+
 }
 
 @media (--break-3) {

--- a/src/components/posts/PostHeader.css
+++ b/src/components/posts/PostHeader.css
@@ -4,7 +4,7 @@
 .CategoryHeader,
 .RepostHeader {
   position: relative;
-  height: rem(60);
+  height: 60px;
   font-size: 14px;
   color: #aaa;
 }

--- a/src/components/posts/PostRenderables.js
+++ b/src/components/posts/PostRenderables.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
+import classNames from 'classnames'
 import Avatar from '../assets/Avatar'
 import { UserDrawer } from '../users/UserRenderables'
 import ContentWarningButton from '../posts/ContentWarningButton'
@@ -164,11 +165,11 @@ CategoryHeader.propTypes = {
   post: PropTypes.object,
 }
 
-export const RepostHeader = ({ post, repostAuthor, repostedBy }) => {
+export const RepostHeader = ({ post, repostAuthor, repostedBy, inUserDetail }) => {
   if (!post || !repostedBy) { return null }
   const postDetailPath = getPostDetailPath(repostAuthor, post)
   return (
-    <header className="RepostHeader" key={`RepostHeader_${post.id}`}>
+    <header className={classNames('RepostHeader', { inUserDetail })} key={`RepostHeader_${post.id}`}>
       <div className="RepostHeaderAuthor">
         <Link className="PostHeaderLink" to={`/${repostAuthor.username}`}>
           <Avatar
@@ -209,6 +210,7 @@ export const RepostHeader = ({ post, repostAuthor, repostedBy }) => {
 }
 
 RepostHeader.propTypes = {
+  inUserDetail: PropTypes.bool,
   post: PropTypes.object,
   repostAuthor: PropTypes.object,
   repostedBy: PropTypes.object,

--- a/src/components/users/UserParts.css
+++ b/src/components/users/UserParts.css
@@ -229,10 +229,15 @@ User Info */
 
 .UserInfoCell.inUserProfileCard > .UserShortBio {
   height: 85px;
+  line-height: 16px;
 }
 
 .UserLocation {
   margin-bottom: 0;
+}
+
+.UserShortBio a {
+  border-color: #aaa;
 }
 
 /* -------------------------------------

--- a/src/components/users/UserParts.css
+++ b/src/components/users/UserParts.css
@@ -229,7 +229,6 @@ User Info */
 
 .UserInfoCell.inUserProfileCard > .UserShortBio {
   height: 85px;
-  line-height: 16px;
 }
 
 .UserLocation {
@@ -255,7 +254,7 @@ User Links */
 .UserExternalLinksLabel {
   display: block;
   margin-bottom: 10px;
-  line-height: 16px;
+  line-height: 1.3;
 }
 
 .UserExternalLinksLabel > a {

--- a/src/components/users/UserRenderables.js
+++ b/src/components/users/UserRenderables.js
@@ -146,7 +146,6 @@ export const UserProfile = ({ isLoggedIn, user, onClickCollab,
       priority={user.relationshipPriority}
       size="large"
       sources={user.avatar}
-      to={`/${user.username}`}
       useGif={(user.viewsAdultContent || !user.postsAdultContent)}
       userId={`${user.id}`}
       username={user.username}

--- a/src/components/users/UserRenderables.js
+++ b/src/components/users/UserRenderables.js
@@ -122,7 +122,7 @@ export const UserProfileCard = ({ isMobile, onClickCollab, onClickHireMe, user }
       /> : null
     }
     <BackgroundImage
-      className="hasOverlay inUserProfileCard"
+      className="hasOverlay6 inUserProfileCard"
       sources={user.coverImage}
       to={`/${user.username}`}
     />

--- a/src/components/views/UserDetail.js
+++ b/src/components/views/UserDetail.js
@@ -35,7 +35,6 @@ export const UserDetail = (props) => {
   const { isLoggedIn, isPostHeaderHidden, isSelf } = props
   const { hasSaidHelloTo, hasZeroFollowers, hasZeroPosts } = props
   const { activeType, onSubmitHello, onTabClick, streamAction, tabs, user } = props
-  // const useGif = user.viewsAdultContent || !user.postsAdultContent
 
   // construct component props
   const tabProps = { activeType, className: 'LabelTabList', tabClasses: 'LabelTab', tabs }

--- a/src/containers/PostContainer.js
+++ b/src/containers/PostContainer.js
@@ -177,7 +177,12 @@ class PostContainer extends Component {
     let postHeader
     if (isRepost) {
       const { authorLinkObject } = this.props
-      const reProps = { post, repostAuthor: authorLinkObject, repostedBy: author }
+      const reProps = {
+        inUserDetail: isPostHeaderHidden,
+        post,
+        repostAuthor: authorLinkObject,
+        repostedBy: author,
+      }
       postHeader = <RepostHeader {...reProps} />
     } else if (isPostHeaderHidden) {
       postHeader = null

--- a/src/containers/settings/Settings.js
+++ b/src/containers/settings/Settings.js
@@ -319,7 +319,7 @@ class Settings extends Component {
             title="Upload Header"
           />
           <BackgroundImage
-            className="hasOverlay inSettings"
+            className="hasOverlay6 inSettings"
             sources={profile.coverImage}
             useGif
           />


### PR DESCRIPTION
A bunch of smaller UI updates and bug fixes from the Profile 2.0 sprint.

- [x] 2d411bd Remove the large profile Avatar links
- [x] 13fcca7 Bump ScrollToContentIcon down a couple of pixels
- [x] ffbf980 Normalize the border with external links and bio
- [x] 968ac02 Fix the height of the RepostHeader
- [x] 76bac17 Be more specific around the hasOverlay opacity
- [x] f7d2150 Update RepostHeader layout in UserDetail template

### Tracker stories
[#131129719](https://www.pivotaltracker.com/story/show/131129719)
[#130943371](https://www.pivotaltracker.com/story/show/130943371)
[#131014621](https://www.pivotaltracker.com/story/show/131014621)