### PR TITLE
Add conditional for determining notification dot for initial state

### DIFF
--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -177,7 +177,9 @@ export const gui = (state = initialState, action = { type: '' }) => {
     case HEAD_FAILURE:
       return { ...state, isNotificationsUnread: false }
     case HEAD_SUCCESS:
-      if (action.payload.serverStatus === 204) {
+      if (action.payload.serverStatus === 304) {
+        return { ...state, isNotificationsUnread: false }
+      } else if (action.payload.serverStatus === 204) {
         return { ...state, isNotificationsUnread: true }
       }
       return state


### PR DESCRIPTION
- The API used to always return a 204 response for head requests, which
would unfortunately always cause the initial state for user’s to have
a red dot for notifications despite them actually having new
notifications. We have now changed the API to return a 304 if there
are no new notifications and a 204 if there are.