### PR TITLE
Fixes the missing gradient for discover tab bars

### DIFF
--- a/src/components/tabs/CategoryTabBar.css
+++ b/src/components/tabs/CategoryTabBar.css
@@ -39,7 +39,7 @@
   width: 20px;
   height: 100%;
   content: "";
-  background: linear-gradient(to right, rgba(#e8e8e8, 0) 0%, rgba(#e8e8e8, 1) 90%);
+  background: linear-gradient(to right, rgba(232, 232, 232, 0) 0%, rgba(232, 232, 232, 1) 90%);
 }
 
 .CategoryLabelTab {


### PR DESCRIPTION
Makes this 👇 
![screen shot 2016-10-14 at 2 16 42 pm](https://cloud.githubusercontent.com/assets/78967/19401694/fd2d6ac2-9219-11e6-8c8f-b4a6ac242a88.png)

look like 👇 
![screen shot 2016-10-14 at 2 16 08 pm](https://cloud.githubusercontent.com/assets/78967/19401703/0ae8687e-921a-11e6-8c38-9c7e45fc4142.png)

👌 

[Fixes: #132350455](https://www.pivotaltracker.com/story/show/132350455)