### PR TITLE
Send users who have onboarding version 0 back

### DIFF
--- a/src/containers/EnterContainer.js
+++ b/src/containers/EnterContainer.js
@@ -71,7 +71,7 @@ class EnterContainer extends Component {
     if (typeof this.props.webOnboardingVersionSeen === 'undefined' &&
         this.props.webOnboardingVersionSeen !== nextProps.webOnboardingVersionSeen) {
       const { currentStream, dispatch } = this.props
-      if (!nextProps.webOnboardingVersionSeen) {
+      if (!nextProps.webOnboardingVersionSeen || nextProps.webOnboardingVersionSeen === '0') {
         dispatch(replace({ pathname: '/onboarding' }))
         dispatch(saveProfile({ web_onboarding_version: ONBOARDING_VERSION }))
       } else {


### PR DESCRIPTION
Our fix for onboarding version 1 to not have existing users go through
onboarding was to set their version to nil and new ones to '0'. We were
checking for onboarding versions matching and if they didn't we would
send them through it. Now initial users should be set to nil and thus
sent through version 2 of onboarding along with old initial users.

/cc @Justin-Holmes @jayzes 