### PR TITLE
Add configuration to allow certain attributes

### DIFF
--- a/src/selectors/user.js
+++ b/src/selectors/user.js
@@ -36,7 +36,9 @@ export const selectRelationshipPriority = createSelector(
 
 export const selectTruncatedShortBio = createSelector(
   [selectUserFromPropsUserId], user =>
-    trunc(user.formattedShortBio || '', 160)
+    trunc(user.formattedShortBio || '', 160, { sanitizer:
+      { allowedAttributes: { img: ['align', 'alt', 'class', 'height', 'src', 'width'] } },
+    })
 )
 
 export const selectUserMetaDescription = createSelector(


### PR DESCRIPTION
This adds in the attributes that the api returns to us from the truncation of the short bio. @jayzes not sure if we need to add more of these, but I think we are good based off of the defaults: https://github.com/bevacqua/insane#defaults.