### PR TITLE
Adjust the max-height of profile bios

### DIFF
--- a/src/components/users/UserParts.css
+++ b/src/components/users/UserParts.css
@@ -257,7 +257,7 @@ User Info */
 
 .UserShortBio {
   position: relative;
-  max-height: 103px;
+  max-height: 100px;
   overflow: hidden;
   line-height: 1.3;
   word-wrap: break-word;
@@ -297,6 +297,7 @@ User Info */
 
 @media (--break-2) {
   .MoreBioButton {
+    margin-top: 10px;
     font-size: 14px;
     line-height: 1;
     border-bottom: 1px solid;


### PR DESCRIPTION
This seems to be a better number for compensating with line breaks and other goodies. It's still a crap shoot based on the formatting of the text for each user.

🤕 

[#132797869](https://www.pivotaltracker.com/story/show/132797869)