### PR TITLE
Ensure selection is text for FF inputs

### DIFF
--- a/src/components/editor/InputComponent.js
+++ b/src/components/editor/InputComponent.js
@@ -47,6 +47,8 @@ function toggleTools(input) {
 
 function selectionIsText() {
   let parent = window.getSelection().focusNode
+  // Firefox is always reporting null for focusNode
+  if (!parent && isFirefox() && document.activeElement.tagName === 'INPUT') { return true }
   while (parent) {
     if (parent.classList && parent.classList.contains('text')) {
       return true

--- a/src/components/editor/InputComponent.js
+++ b/src/components/editor/InputComponent.js
@@ -48,7 +48,9 @@ function toggleTools(input) {
 function selectionIsText() {
   let parent = window.getSelection().focusNode
   // Firefox is always reporting null for focusNode
-  if (!parent && isFirefox() && document.activeElement.tagName === 'INPUT') { return true }
+  parent = (!parent && isFirefox() && document.activeElement.tagName === 'INPUT') ?
+    document.activeElement :
+    parent
   while (parent) {
     if (parent.classList && parent.classList.contains('text')) {
       return true

--- a/src/components/editor/InputComponent.js
+++ b/src/components/editor/InputComponent.js
@@ -47,7 +47,7 @@ function toggleTools(input) {
 
 function selectionIsText() {
   let parent = window.getSelection().focusNode
-  // Firefox is always reporting null for focusNode
+  // Firefox more often than not reports null for focusNode
   parent = (!parent && isFirefox() && document.activeElement.tagName === 'INPUT') ?
     document.activeElement :
     parent


### PR DESCRIPTION
Firefox, more often than not, reports `null` for `focusNode`.. yay browsers!

[Finishes: #135366511](https://www.pivotaltracker.com/story/show/135366511)