### PR TITLE
Fix FF location thing... again

### DIFF
--- a/src/components/editor/InputComponent.js
+++ b/src/components/editor/InputComponent.js
@@ -47,10 +47,9 @@ function toggleTools(input) {
 
 function selectionIsText() {
   let parent = window.getSelection().focusNode
-  // Firefox more often than not reports null for focusNode
-  parent = (!parent && isFirefox() && document.activeElement.tagName === 'INPUT') ?
-    document.activeElement :
-    parent
+  // Firefox often reports null or something else entirely for focusNode
+  parent = (isFirefox() && document.activeElement.tagName === 'INPUT') ?
+    document.activeElement : parent
   while (parent) {
     if (parent.classList && parent.classList.contains('text')) {
       return true


### PR DESCRIPTION
Just skip focusNode for FF and use active element

There were times that focusNode on FF would report things like the HeroContainer or the AppContainer instead of the focused element. This just removes relying on focusNode for FF and utilizes the active element. Not sure if this will totally fix it but...

[Fixes: #135366511](https://www.pivotaltracker.com/story/show/135366511)