### PR TITLE
Handle lack of user-agent header gracefully.

### DIFF
--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -163,7 +163,7 @@ export function canPrerenderRequest(req) {
     return false
   }
   // Don't pre-render for ello android app
-  if (req.get('user-agent').includes('Ello Android')) {
+  if ((req.get('user-agent') || '').includes('Ello Android')) {
     return false
   }
   return values(noPreRenderPaths).every(regex =>

--- a/test/server/server_test.js
+++ b/test/server/server_test.js
@@ -48,6 +48,16 @@ describe('isomorphically rendering on the server', () => {
         })).to.be.false
       })
     })
+
+    it('should return true with loggedOutPaths if missing user agent', () => {
+      ['/mk', '/666', '/discover', '/search'].forEach((path) => {
+        expect(canPrerenderRequest({
+          url: path,
+          get: () => undefined,
+          cookies: {},
+        })).to.be.true
+      })
+    })
   })
 
   describe('app', function () {


### PR DESCRIPTION
Honestly this is probably weird bots (spam?) or scrapers, but in case it
is normal users this fixes appropriately.

Related error: https://app.honeybadger.io/projects/47963/faults/32214019/07a54044-d296-11e6-8f0c-0183f78a4fd0#notice-summary