### PR TITLE
Add a dismiss icon to the bio modal

### DIFF
--- a/src/components/dialogs/Dialog.css
+++ b/src/components/dialogs/Dialog.css
@@ -43,9 +43,24 @@
   border-bottom: 1px solid;
 }
 
+.TextDialog .Dismiss {
+  position: fixed;
+  top: 5px;
+  right: 5px;
+}
+
+.no-touch .Dismiss:hover {
+  color: #aaa;
+}
+
 @media (--break-2) {
   .Modal > .Dialog {
     padding: 20px;
+  }
+
+  .TextDialog .Dismiss {
+    top: 10px;
+    right: 10px;
   }
 }
 

--- a/src/components/dialogs/DialogRenderables.js
+++ b/src/components/dialogs/DialogRenderables.js
@@ -1,12 +1,13 @@
 /* eslint-disable react/no-danger */
 
 import React, { PropTypes } from 'react'
+import { XIcon } from '../assets/Icons'
 
 export const TextMarkupDialog = ({ html }) =>
-  <div
-    className="Dialog TextDialog TextMarkupDialog"
-    dangerouslySetInnerHTML={{ __html: html }}
-  />
+  <div className="Dialog TextDialog TextMarkupDialog">
+    <div className="TextDialogText" dangerouslySetInnerHTML={{ __html: html }} />
+    <button className="CloseModal Dismiss"><XIcon /></button>
+  </div>
 
 
 TextMarkupDialog.propTypes = {


### PR DESCRIPTION
This allows an out for smaller devices like the iPhone SE.

This only adds it to the bio modal and not the remaining modals which we've talked about. I'd like to leave that task to when we break dialogs out to DialogRenderables. Something we can do in the future off of master instead.

[Finishes: #137124933](https://www.pivotaltracker.com/story/show/137124933)