### PR TITLE
Adds robot instructions for Search meta tags

### DIFF
--- a/src/containers/MetaContainer.js
+++ b/src/containers/MetaContainer.js
@@ -13,7 +13,7 @@ import {
   selectPostMetaTitle,
   selectPostMetaUrl,
 } from '../selectors/post'
-import { selectPathname, selectPropsQueryTerms, selectViewNameFromRoute } from '../selectors/routing'
+import { selectPathname, selectQueryTerms, selectViewNameFromRoute } from '../selectors/routing'
 import {
   selectUserMetaDescription,
   selectUserMetaImage,
@@ -27,9 +27,8 @@ const selectMetaPageType = createSelector(
 )
 
 const selectDefaultMetaRobots = createSelector(
-  [selectViewNameFromRoute, selectPropsQueryTerms], (viewName, terms) => {
+  [selectViewNameFromRoute, selectQueryTerms], (viewName, terms) => {
     // Terms seems to be undefined at mount time..
-    console.log(viewName, terms)
     if (viewName === 'search' && terms && terms.length) {
       return terms.charAt(0) === '#' ? 'index, follow' : 'noindex, follow'
     }

--- a/src/containers/MetaContainer.js
+++ b/src/containers/MetaContainer.js
@@ -28,7 +28,6 @@ const selectMetaPageType = createSelector(
 
 const selectDefaultMetaRobots = createSelector(
   [selectViewNameFromRoute, selectQueryTerms], (viewName, terms) => {
-    // Terms seems to be undefined at mount time..
     if (viewName === 'search' && terms && terms.length) {
       return terms.charAt(0) === '#' ? 'index, follow' : 'noindex, follow'
     }
@@ -38,7 +37,6 @@ const selectDefaultMetaRobots = createSelector(
 
 function mapStateToProps(state, props) {
   const pagination = selectPagination(state, props)
-  console.log('robots', selectDefaultMetaRobots(state, props))
   return {
     defaultMetaRobots: selectDefaultMetaRobots(state, props),
     discoverMetaData: selectDiscoverMetaData(state, props),

--- a/src/reducers/routing.js
+++ b/src/reducers/routing.js
@@ -16,7 +16,7 @@ export default (state = initialState, { type, payload }) => {
       location: {
         pathname: get(payload, 'locationBeforeTransitions.pathname', get(payload, 'pathname')),
         state: get(payload, 'locationBeforeTransitions.state', get(payload, 'state')),
-        terms: get(payload, 'locationBeforeTransitions.query.terms', get(payload, 'query.terms', null)),
+        terms: get(payload, 'locationBeforeTransitions.query.terms', get(payload, 'query.terms', undefined)),
       },
       locationBeforeTransitions: payload.locationBeforeTransitions || payload,
       previousPath: state.getIn(['location', 'pathname']),

--- a/src/reducers/routing.js
+++ b/src/reducers/routing.js
@@ -16,6 +16,7 @@ export default (state = initialState, { type, payload }) => {
       location: {
         pathname: get(payload, 'locationBeforeTransitions.pathname', get(payload, 'pathname')),
         state: get(payload, 'locationBeforeTransitions.state', get(payload, 'state')),
+        terms: get(payload, 'locationBeforeTransitions.query.terms', get(payload, 'query.terms', null)),
       },
       locationBeforeTransitions: payload.locationBeforeTransitions || payload,
       previousPath: state.getIn(['location', 'pathname']),

--- a/src/selectors/routing.js
+++ b/src/selectors/routing.js
@@ -21,6 +21,7 @@ export const selectPreviousPath = state => state.routing.get('previousPath')
 
 // state.routing.location.xxx
 export const selectPathname = state => state.routing.getIn(['location', 'pathname'])
+export const selectQueryTerms = state => state.routing.getIn(['location', 'terms'])
 
 // Memoized selectors
 export const selectViewNameFromRoute = createSelector(

--- a/test/unit/reducers/routing_test.js
+++ b/test/unit/reducers/routing_test.js
@@ -18,6 +18,7 @@ describe('routing reducer', () => {
       location: {
         pathname: '/discover/trending',
         state: undefined,
+        terms: undefined,
       },
       locationBeforeTransitions: { pathname: '/discover/trending' },
       previousPath: undefined,
@@ -27,6 +28,26 @@ describe('routing reducer', () => {
       const action = { type: LOCATION_CHANGE, payload: { locationBeforeTransitions: { pathname: '/discover/trending' } } }
       const state = reducer(initialState, action)
       expect(state).to.equal(subject)
+    })
+
+    it('LOCATION_CHANGE updates the query.terms when present', () => {
+      const action = { type: LOCATION_CHANGE, payload: { locationBeforeTransitions: { query: { terms: 'terms' } } } }
+      const state = reducer(initialState, action)
+      expect(state.getIn(['location', 'terms'])).to.equal('terms')
+    })
+
+    it('LOCATION_CHANGE updates the query.terms from payload', () => {
+      const action = { type: LOCATION_CHANGE, payload: { query: { terms: 'terms' } } }
+      const state = reducer(initialState, action)
+      expect(state.getIn(['location', 'terms'])).to.equal('terms')
+    })
+
+    it('LOCATION_CHANGE resets the terms to undefined when missing', () => {
+      const action = { type: LOCATION_CHANGE, payload: { query: { terms: 'terms' } } }
+      let state = reducer(initialState, action)
+      expect(state.getIn(['location', 'terms'])).to.equal('terms')
+      state = reducer(state, { type: LOCATION_CHANGE, payload: { locationBeforeTransitions: { pathname: '/discover/trending' } } })
+      expect(state.getIn(['location', 'terms'])).to.equal(undefined)
     })
 
     it('A non LOCATION_CHANGE action type does not update the routing', () => {

--- a/test/unit/selectors/routing_test.js
+++ b/test/unit/selectors/routing_test.js
@@ -6,6 +6,7 @@ import {
   selectLocation,
   selectPreviousPath,
   selectPathname,
+  selectQueryTerms,
   selectViewNameFromRoute,
 } from '../../../src/selectors/routing'
 
@@ -19,7 +20,7 @@ describe('routing selectors', () => {
     routing = Immutable.fromJS({
       location: {
         pathname: '/state',
-        query: { terms: 'state.query.terms', type: 'state.query.type' },
+        terms: 'state.query.terms',
       },
       previousPath: 'state.previousPath',
     })
@@ -76,6 +77,12 @@ describe('routing selectors', () => {
     it('returns the state.routing.location.pathname', () => {
       const props = { ...propsLocation }
       expect(selectPathname(state, props)).to.deep.equal(state.routing.getIn(['location', 'pathname']))
+    })
+  })
+
+  context('#selectQueryTerms', () => {
+    it('returns the routing.location.query.terms', () => {
+      expect(selectQueryTerms(state)).to.equal('state.query.terms')
     })
   })
 


### PR DESCRIPTION
Update the meta tags for robots on search with the following.

1. If query starts with `#`: `index, follow`
2. else if query still has a length use `noindex, follow`
3. otherwise set it to null which won't render the robots meta tag into the document

This does work when there is a deep link into the page (i.e. /search?terms=%23yep) but since we don't statically render anything with search, it will only show up after the js has had a chance to load and run.

I updated the routing reducer with the `terms` property as well. For some reason (I'm assuming since it's running an asynchronous location change through react-router) it wasn't available on the MetaContainer's `props.params` so I just added it to the routing reducer. 

I'm happy to walk anyone through this one.

[#135175181](https://www.pivotaltracker.com/story/show/135175181)