### PR TITLE
Use AUTH_DOMAIN to pick internal vs external links

### DIFF
--- a/src/components/notifications/NotificationRenderables.js
+++ b/src/components/notifications/NotificationRenderables.js
@@ -52,8 +52,9 @@ PostTextLink.propTypes = {
 }
 
 export const AnnouncementNotification = (props, context) => {
-  const isInternalLink = props.ctaHref && props.ctaHref[0] === '/'
-  const isExternalLink = props.ctaHref && props.ctaHref[0] !== '/'
+  const re = new RegExp(ENV.AUTH_DOMAIN.replace('https://', ''))
+  const isInternalLink = props.ctaHref && (props.ctaHref[0] === '/' || re.test(props.ctaHref))
+  const isExternalLink = props.ctaHref && (props.ctaHref[0] !== '/' || !re.test(props.ctaHref))
   let linkProps = null
   if (isInternalLink) {
     linkProps = {


### PR DESCRIPTION
This is the same logic as [Hero CTA's](https://github.com/ello/webapp/blob/master/src/components/heros/HeroParts.js#L37-L46). Still supporting pathname links.

[Fixes: #137935051](https://www.pivotaltracker.com/story/show/137935051)