### PR TITLE
Mark empty responses for announcments as read

### DIFF
--- a/src/reducers/json.js
+++ b/src/reducers/json.js
@@ -437,7 +437,7 @@ export default function json(state = {}, action = { type: '' }) {
   }
   const { response } = action.payload
   // TODO: Add to immutable branch
-  if (!response && action.meta.mappingType === MAPPING_TYPES.ANNOUNCEMENTS) {
+  if (!response && get(action, ['meta', 'mappingType'], null) === MAPPING_TYPES.ANNOUNCEMENTS) {
     return methods.markAnnouncementRead(state, action)
   }
   if (!response) { return state }

--- a/src/reducers/json.js
+++ b/src/reducers/json.js
@@ -436,6 +436,10 @@ export default function json(state = {}, action = { type: '' }) {
       return state
   }
   const { response } = action.payload
+  // TODO: Add to immutable branch
+  if (!response && action.meta.mappingType === MAPPING_TYPES.ANNOUNCEMENTS) {
+    return methods.markAnnouncementRead(state, action)
+  }
   if (!response) { return state }
   // parse the linked part of the response into the state
   methods.parseLinked(response.linked, newState)


### PR DESCRIPTION
An empty response can come from another browser, device or maybe even another tab. This should allow the notification to be marked as read in the current session. omg web sockets please.

[Finishes: #137935565](https://www.pivotaltracker.com/story/show/137935565)