### PR TITLE
Update onboarding with collaborate and required categories

### DIFF
--- a/src/components/assets/Icons.js
+++ b/src/components/assets/Icons.js
@@ -121,6 +121,11 @@ export const XIcon = () =>
     </g>
   </SVGIcon>
 
+export const CheckIcon = () =>
+  <SVGIcon className="CheckIcon">
+    <CheckShape />
+  </SVGIcon>
+
 // From Footer
 export const PhoneIcon = () =>
   <SVGIcon className="PhoneIcon">

--- a/src/components/forms/Preference.css
+++ b/src/components/forms/Preference.css
@@ -29,3 +29,122 @@
   right: 0;
 }
 
+/* Onboarding specific.. resetting is a bummer :( */
+
+.OnboardingPreferences {
+  margin-top: -25px;
+}
+
+.OnboardingPreference.Preference {
+  padding-top: 25px;
+  padding-bottom: 25px;
+  margin-right: 15px;
+  margin-left: 15px;
+  border-top: 1px solid #e5e5e5;
+}
+
+.OnboardingPreference.Preference:first-child {
+  border-top: 0;
+}
+
+.OnboardingPreference.Preference dl {
+  width: auto;
+  max-width: 290px;
+}
+
+.OnboardingPreference.Preference dt {
+  font-size: 18px;
+}
+
+.OnboardingPreference.Preference dd {
+  margin-top: 100px;
+}
+
+.OnboardingPreference .ToggleControl {
+  top: 75px;
+  right: auto;
+  left: 0;
+  width: 100%;
+  max-width: 290px;
+  height: 50px;
+  font-size: 16px;
+  line-height: 50px;
+  border-radius: 5px;
+}
+
+@media (--break-2) {
+  .OnboardingPreferences {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: calc(100vh - 80px);
+    margin-top: 0;
+  }
+
+  .OnboardingPreference.Preference {
+    /* max-width: 420px; */
+    padding-right: 10px;
+    padding-left: 10px;
+    margin-right: 0;
+    margin-left: 0;
+    border-top: 0;
+    border-left: 1px solid #e5e5e5;
+  }
+
+  .OnboardingPreference.Preference:first-child {
+    border-left: 0;
+  }
+
+  .OnboardingPreference + .OnboardingPreference::before {
+    width: 100px;
+    height: 330px;
+    content: "";
+    background-color: #f0f;
+  }
+
+  .OnboardingPreference.Preference dl {
+    /* max-width: none; */
+    max-width: 330px;
+  }
+
+  .OnboardingPreference.Preference dt {
+    font-size: 24px;
+  }
+
+  .OnboardingPreference.Preference dd {
+    margin-top: 100px;
+  }
+
+  .OnboardingPreference .ToggleControl {
+    left: 10px;
+    width: calc(100% - 20px);
+    max-width: 330px;
+    height: 70px;
+    font-size: 18px;
+    line-height: 70px;
+  }
+}
+
+@media (--break-3) {
+  .OnboardingPreference.Preference {
+    padding-right: 40px;
+    padding-left: 40px;
+  }
+
+  .OnboardingPreference .ToggleControl {
+    left: 40px;
+    width: 100%;
+  }
+}
+
+@media (--break-4) {
+  .OnboardingPreference.Preference {
+    padding-right: 90px;
+    padding-left: 90px;
+  }
+
+  .OnboardingPreference .ToggleControl {
+    left: 90px;
+  }
+}
+

--- a/src/components/forms/Preference.js
+++ b/src/components/forms/Preference.js
@@ -1,33 +1,42 @@
 /* eslint-disable react/no-danger */
-
 import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { camelize } from 'humps'
+import classNames from 'classnames'
+import { selectIsOnboardingView } from '../../selectors/routing'
 import ToggleControl from '../forms/ToggleControl'
 import { profilePath } from '../../networking/api'
 
-const Preference = ({ definition, id, isChecked, isDisabled, onToggleChange }) =>
-  <form action={profilePath().path} className="Preference" method="POST">
-    <dl>
-      <dt>{definition.term ? definition.term : ''}</dt>
-      <dd dangerouslySetInnerHTML={{ __html: definition.desc ? definition.desc : '' }} />
-    </dl>
-    <ToggleControl
-      id={id}
-      isChecked={isChecked}
-      isDisabled={isDisabled}
-      onChange={onToggleChange}
-    />
-  </form>
+const Preference = (props) => {
+  const { className, definition, id, isChecked, isDisabled, isOnboarding, onToggleChange } = props
+  return (
+    <form action={profilePath().path} className={classNames(className, 'Preference')} method="POST">
+      <dl>
+        <dt>{definition.term ? definition.term : ''}</dt>
+        <dd dangerouslySetInnerHTML={{ __html: definition.desc ? definition.desc : '' }} />
+      </dl>
+      <ToggleControl
+        id={id}
+        isChecked={isChecked}
+        isDisabled={isDisabled}
+        hasIcon={isOnboarding}
+        onChange={onToggleChange}
+      />
+    </form>
+  )
+}
 
 Preference.propTypes = {
+  className: PropTypes.string,
   definition: PropTypes.object.isRequired,
   id: PropTypes.string.isRequired,
   isChecked: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  isOnboarding: PropTypes.bool.isRequired,
   onToggleChange: PropTypes.func.isRequired,
 }
 Preference.defaultProps = {
+  className: null,
   isChecked: false,
   isDisabled: false,
 }
@@ -36,6 +45,7 @@ function mapStateToProps(state, ownProps) {
   return {
     isChecked: state.profile.get(camelize(ownProps.id)),
     isDisabled: !state.profile.get('isPublic') && ownProps.id === 'has_sharing_enabled',
+    isOnboarding: selectIsOnboardingView(state),
   }
 }
 

--- a/src/components/forms/ToggleControl.css
+++ b/src/components/forms/ToggleControl.css
@@ -39,3 +39,16 @@
   border-color: #aaa;
 }
 
+.ToggleControlIcon {
+  margin-right: 5px;
+  margin-left: -25px;
+}
+
+.ToggleControlIcon .CancelIcon {
+  margin-top: -2px;
+}
+
+.ToggleControlIcon .CheckIcon {
+  margin-top: -4px;
+}
+

--- a/src/components/forms/ToggleControl.js
+++ b/src/components/forms/ToggleControl.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import shallowCompare from 'react-addons-shallow-compare'
 import classNames from 'classnames'
+import { CheckIcon, XIcon } from '../assets/Icons'
 
 class ToggleControl extends Component {
 
@@ -8,12 +9,14 @@ class ToggleControl extends Component {
     id: PropTypes.string.isRequired,
     isChecked: PropTypes.bool,
     isDisabled: PropTypes.bool,
+    hasIcon: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
     isChecked: false,
     isDisabled: false,
+    hasIcon: false,
   }
 
   componentWillMount() {
@@ -50,7 +53,7 @@ class ToggleControl extends Component {
   }
 
   render() {
-    const { id, isDisabled } = this.props
+    const { id, isDisabled, hasIcon } = this.props
     const { checked } = this.state
     return (
       <label
@@ -65,6 +68,11 @@ class ToggleControl extends Component {
           onChange={this.onChangeControl}
           type="checkbox"
         />
+        {hasIcon &&
+          <span className="ToggleControlIcon">
+            {checked ? <CheckIcon /> : <XIcon />}
+          </span>
+        }
         <span>{checked ? 'Yes' : 'No'}</span>
       </label>
     )

--- a/src/components/onboarding/OnboardingCollaborate.js
+++ b/src/components/onboarding/OnboardingCollaborate.js
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react'
+import OnboardingNavbar from './OnboardingNavbar'
+import Preference from '../forms/Preference'
+import { MainView } from '../views/MainView'
+
+type PreferenceType = {
+  desc: string,
+  id: string,
+  term: string,
+}
+
+type Props = {
+  onToggleChange: Function,
+  prefs: Array<PreferenceType>,
+}
+
+const OnboardingCollaborate = (props: Props) =>
+  <MainView className="Onboarding OnboardingCollaborate">
+    {props.prefs.map(pref =>
+      <Preference
+        definition={{ term: pref.term, desc: pref.desc }}
+        id={pref.id}
+        key={`preference_${pref.id}`}
+        onToggleChange={props.onToggleChange}
+      />,
+    )}
+    <OnboardingNavbar />
+  </MainView>
+
+export default OnboardingCollaborate
+

--- a/src/components/onboarding/OnboardingCollaborate.js
+++ b/src/components/onboarding/OnboardingCollaborate.js
@@ -17,14 +17,17 @@ type Props = {
 
 const OnboardingCollaborate = (props: Props) =>
   <MainView className="Onboarding OnboardingCollaborate">
-    {props.prefs.map(pref =>
-      <Preference
-        definition={{ term: pref.term, desc: pref.desc }}
-        id={pref.id}
-        key={`preference_${pref.id}`}
-        onToggleChange={props.onToggleChange}
-      />,
-    )}
+    <div className="OnboardingPreferences">
+      {props.prefs.map(pref =>
+        <Preference
+          className="OnboardingPreference"
+          definition={{ term: pref.term, desc: pref.desc }}
+          id={pref.id}
+          key={`preference_${pref.id}`}
+          onToggleChange={props.onToggleChange}
+        />,
+      )}
+    </div>
     <OnboardingNavbar />
   </MainView>
 

--- a/src/containers/OnboardingCategoriesContainer.js
+++ b/src/containers/OnboardingCategoriesContainer.js
@@ -8,7 +8,7 @@ import { getCategories } from '../actions/discover'
 import { followCategories, saveProfile } from '../actions/profile'
 import { selectOnboardingCategories } from '../selectors/categories'
 
-const CATEGORIES_NEEDED = 3
+const CATEGORIES_NEEDED = 1
 
 function mapStateToProps(state) {
   let categories = selectOnboardingCategories(state)

--- a/src/containers/OnboardingCollaborateContainer.js
+++ b/src/containers/OnboardingCollaborateContainer.js
@@ -1,0 +1,84 @@
+import React, { PropTypes, PureComponent } from 'react'
+import { connect } from 'react-redux'
+import { push } from 'react-router-redux'
+import { selectProfileIsCollaborateable, selectProfileIsHireable } from '../selectors/profile'
+import { trackEvent } from '../actions/analytics'
+import { preferenceToggleChanged } from '../helpers/junk_drawer'
+import OnboardingCollaborate from '../components/onboarding/OnboardingCollaborate'
+
+const prefs = [
+  {
+    id: 'isHireable',
+    term: 'Get Hired yo.',
+    desc: 'Enable brands, publications, and people that want to pay you for your work to email you.',
+  },
+  {
+    id: 'isCollaborateable',
+    term: 'Collaborate with stuff.',
+    desc: 'Enable fellow creators that want to collaborate to email you.',
+  },
+]
+
+function mapStateToProps(state) {
+  return {
+    isCollaborateable: selectProfileIsCollaborateable(state),
+    isHireable: selectProfileIsHireable(state),
+  }
+}
+
+class OnboardingCollaborateContainer extends PureComponent {
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    isCollaborateable: PropTypes.bool.isRequired,
+    isHireable: PropTypes.bool.isRequired,
+  }
+
+  static childContextTypes = {
+    nextLabel: PropTypes.string,
+    onDoneClick: PropTypes.func,
+    onNextClick: PropTypes.func.isRequired,
+  }
+
+  getChildContext() {
+    return {
+      nextLabel: 'Invite Cool People',
+      onDoneClick: this.onDoneClick,
+      onNextClick: this.onNextClick,
+    }
+  }
+
+  onDoneClick = () => {
+    const { dispatch } = this.props
+    dispatch(trackEvent('Onboarding.Collaborate.Done.Clicked'))
+    this.trackOnboardingEvents()
+    dispatch(push('/following'))
+  }
+
+  onNextClick = () => {
+    const { dispatch } = this.props
+    this.trackOnboardingEvents()
+    dispatch(push('/onboarding/invitations'))
+  }
+
+  trackOnboardingEvents = () => {
+    const { dispatch, isCollaborateable, isHireable } = this.props
+    if (isCollaborateable) {
+      dispatch(trackEvent('Onboarding.Collaborate.isCollaborateable.Yes'))
+    }
+    if (isHireable) {
+      dispatch(trackEvent('Onboarding.Collaborate.isHireable.Yes'))
+    }
+  }
+
+  render() {
+    return (
+      <OnboardingCollaborate
+        onToggleChange={preferenceToggleChanged}
+        prefs={prefs}
+      />
+    )
+  }
+}
+
+export default connect(mapStateToProps)(OnboardingCollaborateContainer)
+

--- a/src/containers/OnboardingCollaborateContainer.js
+++ b/src/containers/OnboardingCollaborateContainer.js
@@ -9,12 +9,12 @@ import OnboardingCollaborate from '../components/onboarding/OnboardingCollaborat
 const prefs = [
   {
     id: 'isHireable',
-    term: 'Get Hired yo.',
+    term: 'Get Hired',
     desc: 'Enable brands, publications, and people that want to pay you for your work to email you.',
   },
   {
     id: 'isCollaborateable',
-    term: 'Collaborate with stuff.',
+    term: 'Collaborate',
     desc: 'Enable fellow creators that want to collaborate to email you.',
   },
 ]

--- a/src/containers/OnboardingSettingsContainer.js
+++ b/src/containers/OnboardingSettingsContainer.js
@@ -78,7 +78,7 @@ class OnboardingSettingsContainer extends PureComponent {
       isAvatarBlank,
       isCoverImageBlank,
       isMobile,
-      nextLabel: 'Invite Cool People',
+      nextLabel: 'Get Hired & Collaborate',
       onDoneClick: isNextDisabled ? null : this.onDoneClick,
       onNextClick: this.onNextClick,
       saveAvatar: bindActionCreators(saveAvatar, dispatch),
@@ -96,7 +96,7 @@ class OnboardingSettingsContainer extends PureComponent {
   onNextClick = () => {
     const { dispatch } = this.props
     this.trackOnboardingEvents()
-    dispatch(push('/onboarding/invitations'))
+    dispatch(push('/onboarding/collaborate'))
   }
 
   trackOnboardingEvents = () => {

--- a/src/containers/ViewportContainer.js
+++ b/src/containers/ViewportContainer.js
@@ -12,7 +12,7 @@ import {
   selectScrollOffset,
 } from '../selectors/gui'
 import { selectModalType } from '../selectors/modal'
-import { selectPathname, selectViewNameFromRoute } from '../selectors/routing'
+import { selectIsOnboardingView, selectPathname, selectViewNameFromRoute } from '../selectors/routing'
 import { setIsNavbarHidden, setViewportSizeAttributes } from '../actions/gui'
 import { addScrollObject, removeScrollObject } from '../components/viewport/ScrollComponent'
 import {
@@ -24,10 +24,6 @@ import { Viewport } from '../components/viewport/Viewport'
 
 const selectIsAuthenticationView = createSelector(
   [selectViewNameFromRoute], viewName => viewName === 'authentication' || viewName === 'join',
-)
-
-const selectIsOnboardingView = createSelector(
-  [selectViewNameFromRoute], viewName => viewName === 'onboarding',
 )
 
 export const selectUserDetailPathClassName = createSelector(

--- a/src/routes/onboarding/index.js
+++ b/src/routes/onboarding/index.js
@@ -1,4 +1,5 @@
 import OnboardingCategoriesContainer from '../../containers/OnboardingCategoriesContainer'
+import OnboardingCollaborateContainer from '../../containers/OnboardingCollaborateContainer'
 import OnboardingInvitationsContainer from '../../containers/OnboardingInvitationsContainer'
 import OnboardingSettingsContainer from '../../containers/OnboardingSettingsContainer'
 
@@ -13,6 +14,12 @@ export default [
     path: 'onboarding/settings',
     getComponent(location, cb) {
       cb(null, OnboardingSettingsContainer)
+    },
+  },
+  {
+    path: 'onboarding/collaborate',
+    getComponent(location, cb) {
+      cb(null, OnboardingCollaborateContainer)
     },
   },
   {

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -19,6 +19,8 @@ export const selectHasAvatarPresent = state => state.profile.get('hasAvatarPrese
 export const selectHasCoverImagePresent = state => state.profile.get('hasCoverImagePresent', false)
 export const selectId = state => state.profile.get('id')
 export const selectIsPublic = state => state.profile.get('isPublic')
+export const selectProfileIsCollaborateable = state => state.profile.get('isCollaborateable', false)
+export const selectProfileIsHireable = state => state.profile.get('isHireable', false)
 export const selectLocation = state => state.profile.get('location', '')
 export const selectMarketingVersion = state => state.profile.get('marketingVersion')
 export const selectMutedCount = state => state.profile.get('mutedCount')

--- a/src/selectors/routing.js
+++ b/src/selectors/routing.js
@@ -65,6 +65,10 @@ export const selectViewNameFromRoute = createSelector(
   },
 )
 
+export const selectIsOnboardingView = createSelector(
+  [selectViewNameFromRoute], viewName => viewName === 'onboarding',
+)
+
 export const selectIsPostDetail = createSelector(
   [selectViewNameFromRoute], viewName => viewName === 'postDetail',
 )

--- a/test/unit/selectors/profile_test.js
+++ b/test/unit/selectors/profile_test.js
@@ -19,6 +19,8 @@ import {
   selectIsCoverImageBlank,
   selectIsInfoFormBlank,
   selectIsPublic,
+  selectProfileIsCollaborateable,
+  selectProfileIsHireable,
   selectLinksAsText,
   selectMarketingVersion,
   selectMutedCount,
@@ -42,6 +44,8 @@ describe('profile selectors', () => {
       hasAvatarPresent: true,
       hasCoverImagePresent: true,
       isPublic: true,
+      isCollaborateable: false,
+      isHireable: true,
       marketingVersion: '1',
       mutedCount: 10,
       registrationId: '1234',
@@ -141,6 +145,18 @@ describe('profile selectors', () => {
   context('#selectIsPublic', () => {
     it('returns the profile.isPublic', () => {
       expect(selectIsPublic(state)).to.deep.equal(state.profile.get('isPublic'))
+    })
+  })
+
+  context('#selectProfileIsCollaborateable', () => {
+    it('returns the profile.isCollaborateable property', () => {
+      expect(selectProfileIsCollaborateable(state)).to.equal(false)
+    })
+  })
+
+  context('#selectProfileIsHireable', () => {
+    it('returns the profile.isHireable property', () => {
+      expect(selectProfileIsHireable(state)).to.equal(true)
     })
   })
 


### PR DESCRIPTION
- [x] 6426c6ab Only require user to follow 1 onboarding category
- [x] 2390fa5f Add selectors for isCollaborateable and isHireable
- [x] 93d8a980 Add collaborate and hire preferences to onboarding
- [x] 93d8a980 Adds the route as `/onboarding/collaborate`
- [x] 133ae2d Style the collaborate preferences and screen
- [x] 808a3733 Update settings to point to the collaborate slide