### PR TITLE
Get a refresh token if needed before a request

### DIFF
--- a/src/sagas/api.js
+++ b/src/sagas/api.js
@@ -11,6 +11,21 @@ import {
 } from '../selectors/authentication'
 import { refreshAuthenticationToken } from '../actions/authentication'
 
+export function getHeaders(accessToken) {
+  return {
+    Accept: 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+  }
+}
+
+export function getHeadHeader(accessToken, lastCheck) {
+  return {
+    ...getHeaders(accessToken),
+    'If-Modified-Since': lastCheck,
+  }
+}
+
 export function* fetchCredentials() {
   const accessToken = yield select(selectAccessToken)
   if (yield select(selectShouldUseAccessToken)) {

--- a/src/sagas/requester.js
+++ b/src/sagas/requester.js
@@ -8,7 +8,7 @@ import { selectRefreshToken } from '../selectors/authentication'
 import { selectLastNotificationCheck } from '../selectors/gui'
 import { selectPathname } from '../selectors/routing'
 import { clearAuthToken, refreshAuthenticationToken } from '../actions/authentication'
-import { fetchCredentials, sagaFetch } from './api'
+import { extractJSON, fetchCredentials, getHeaders, getHeadHeader, sagaFetch } from './api'
 import { openAlert } from '../actions/modals'
 import Dialog from '../components/dialogs/Dialog'
 
@@ -112,33 +112,6 @@ function parseLink(linksHeader) {
     }
   })
   return result
-}
-
-const defaultHeaders = {
-  Accept: 'application/json',
-  'Content-Type': 'application/json',
-}
-
-function getAuthToken(accessToken) {
-  return {
-    ...defaultHeaders,
-    Authorization: `Bearer ${accessToken}`,
-  }
-}
-
-function getHeaders(accessToken) {
-  return getAuthToken(accessToken)
-}
-
-function getHeadHeader(accessToken, lastCheck) {
-  return {
-    ...getAuthToken(accessToken),
-    'If-Modified-Since': lastCheck,
-  }
-}
-
-export function extractJSON(serverResponse) {
-  return serverResponse ? serverResponse.json() : serverResponse
 }
 
 export function* handleRequestError(error, action) {

--- a/src/selectors/authentication.js
+++ b/src/selectors/authentication.js
@@ -1,5 +1,3 @@
-import { createSelector } from 'reselect'
-
 // state.authentication.xxx
 export const selectAccessToken = state => state.authentication.get('accessToken')
 export const selectExpirationDate = state => state.authentication.get('expirationDate')
@@ -7,15 +5,17 @@ export const selectIsLoggedIn = state => state.authentication.get('isLoggedIn')
 export const selectRefreshToken = state => state.authentication.get('refreshToken')
 
 // Memoized selectors
-export const selectShouldUseAccessToken = createSelector(
-  selectAccessToken, selectExpirationDate, selectIsLoggedIn,
-  (accessToken, expirationDate, isLoggedIn) =>
-    isLoggedIn && accessToken && expirationDate > new Date(),
-)
+export const selectShouldUseAccessToken = (state) => {
+  const accessToken = selectAccessToken(state)
+  const expDate = selectExpirationDate(state)
+  const isLoggedIn = selectIsLoggedIn(state)
+  return isLoggedIn && accessToken && expDate > new Date()
+}
 
-export const selectShouldUseRefreshToken = createSelector(
-  selectAccessToken, selectExpirationDate, selectIsLoggedIn,
-  (accessToken, expirationDate, isLoggedIn) =>
-    isLoggedIn && accessToken && !(expirationDate > new Date()),
-)
+export const selectShouldUseRefreshToken = (state) => {
+  const accessToken = selectAccessToken(state)
+  const expDate = selectExpirationDate(state)
+  const isLoggedIn = selectIsLoggedIn(state)
+  return isLoggedIn && accessToken && !(expDate > new Date())
+}
 


### PR DESCRIPTION
This should prevent any request from returning a 401 since it checks the
expiration date to determine if we need a refresh token before making
any other subsequent requests. This also updates the uploader saga a bit
to use methods from the requester and api for shared functionality.

[Fixes #140798705](https://www.pivotaltracker.com/story/show/140798705)