### PR TITLE
Make failure/success/timeout iso render callbacks coexist peacefully

### DIFF
--- a/server-queue-entrypoint.js
+++ b/server-queue-entrypoint.js
@@ -19,7 +19,8 @@ queue.watchStuckJobs()
 librato.configure({ email: process.env.LIBRATO_EMAIL, token: process.env.LIBRATO_TOKEN })
 librato.start()
 librato.on('error', (err) => {
-  console.error(err);
+  Honeybadger.notify(err)
+  console.error(err)
 })
 
 const libratoReporter = setInterval(() => {
@@ -46,6 +47,7 @@ const libratoReporter = setInterval(() => {
 }, 30 * 1000);
 
 queue.on('error', (err) => {
+  Honeybadger.notify(err)
   console.log('An error occurred in Kue: ', err)
 })
 
@@ -111,6 +113,7 @@ process.once('SIGTERM', () => {
   })
 })
 process.once('uncaughtException', (err) => {
+  Honeybadger.notify(err)
   console.error('Something bad happened: ', err)
   queue.shutdown(1000, (err2) => {
     console.error('Kue shutdown result: ', err2 || 'OK')

--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -81,7 +81,6 @@ function saveResponseToCache(cacheKey, body) {
 
 function renderFromServer(req, res, cacheKey, timingHeader) {
   currentToken().then((token) => {
-
     // Kick off the render
     console.log('- Enqueueing render')
     const renderOpts = {

--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -144,8 +144,8 @@ function renderFromServer(req, res, cacheKey, timingHeader) {
       console.log('- Render timed out; falling back to client-side rendering')
       librato.increment('webapp-server-render-timeout')
       res.send(indexStr)
-      job.off('complete', jobCompleteCallback)
-      job.off('failed', jobFailedCallback)
+      job.removeListener('complete', jobCompleteCallback)
+      job.removeListener('failed', jobFailedCallback)
     }, preRenderTimeout)
 
     job.on('complete', jobCompleteCallback)

--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -81,75 +81,80 @@ function saveResponseToCache(cacheKey, body) {
 
 function renderFromServer(req, res, cacheKey, timingHeader) {
   currentToken().then((token) => {
-    // Kick off the render
-    console.log('- Enqueueing render')
-    const renderOpts = {
-      accessToken: token.token.access_token,
-      expiresAt: token.token.expires_at,
-      originalUrl: req.originalUrl,
-      url: req.url,
-      timingHeader,
-    }
-
-    const job = queue
-      .create('render', renderOpts)
-      .ttl(2 * preRenderTimeout) // So we don't lose the job mid-timeout
-      .removeOnComplete(true)
-      .save()
-
-    // Set up our completion/failure/timeout callbacks
-    let renderTimeout
-    const jobCompleteCallback = (result) => {
-      const { type, location, body } = (result || {})
-      switch (type) {
-        case 'redirect':
-          console.log(`-- Redirecting to ${location}`)
-          librato.increment('webapp-server-render-redirect')
-          res.redirect(location)
-          break
-        case 'render':
-          console.log('-- Rendering ISO response')
-          librato.increment('webapp-server-render-success')
-          res.send(body)
-          saveResponseToCache(cacheKey, body)
-          break
-        case 'error':
-          console.log('-- Rendering error response')
-          librato.increment('webapp-server-render-error')
-          res.status(500).end()
-          break
-        case '404':
-          console.log('-- Rendering 404 response')
-          librato.increment('webapp-server-render-404')
-          res.status(404).end()
-          break
-        default:
-          console.log('-- Received unrecognized response')
-          console.log(JSON.stringify(result))
-          librato.increment('webapp-server-render-error')
-          // Fall through
-          res.status(500).end()
+    librato.timing('iso.render_time', (libratoDone) => {
+      // Kick off the render
+      console.log('- Enqueueing render')
+      const renderOpts = {
+        accessToken: token.token.access_token,
+        expiresAt: token.token.expires_at,
+        originalUrl: req.originalUrl,
+        url: req.url,
+        timingHeader,
       }
-      clearTimeout(renderTimeout)
-    }
-    const jobFailedCallback = (errorMessage) => {
-      console.log('- Render job failed!');
-      console.log(JSON.stringify(errorMessage))
-      res.send(indexStr)
-      librato.increment('webapp-server-render-timeout')
-      clearTimeout(renderTimeout)
-    }
 
-    renderTimeout = setTimeout(() => {
-      console.log('- Render timed out; falling back to client-side rendering')
-      librato.increment('webapp-server-render-timeout')
-      res.send(indexStr)
-      job.removeListener('complete', jobCompleteCallback)
-      job.removeListener('failed', jobFailedCallback)
-    }, preRenderTimeout)
+      const job = queue
+        .create('render', renderOpts)
+        .ttl(2 * preRenderTimeout) // So we don't lose the job mid-timeout
+        .removeOnComplete(true)
+        .save()
 
-    job.on('complete', jobCompleteCallback)
-    job.on('failed', jobFailedCallback)
+      // Set up our completion/failure/timeout callbacks
+      let renderTimeout
+      const jobCompleteCallback = (result) => {
+        libratoDone()
+        const { type, location, body } = (result || {})
+        switch (type) {
+          case 'redirect':
+            console.log(`-- Redirecting to ${location}`)
+            librato.increment('webapp-server-render-redirect')
+            res.redirect(location)
+            break
+          case 'render':
+            console.log('-- Rendering ISO response')
+            librato.increment('webapp-server-render-success')
+            res.send(body)
+            saveResponseToCache(cacheKey, body)
+            break
+          case 'error':
+            console.log('-- Rendering error response')
+            librato.increment('webapp-server-render-error')
+            res.status(500).end()
+            break
+          case '404':
+            console.log('-- Rendering 404 response')
+            librato.increment('webapp-server-render-404')
+            res.status(404).end()
+            break
+          default:
+            console.log('-- Received unrecognized response')
+            console.log(JSON.stringify(result))
+            librato.increment('webapp-server-render-error')
+            // Fall through
+            res.status(500).end()
+        }
+        clearTimeout(renderTimeout)
+      }
+      const jobFailedCallback = (errorMessage) => {
+        libratoDone()
+        console.log('- Render job failed!');
+        console.log(JSON.stringify(errorMessage))
+        res.send(indexStr)
+        librato.increment('webapp-server-render-timeout')
+        clearTimeout(renderTimeout)
+      }
+
+      renderTimeout = setTimeout(() => {
+        libratoDone()
+        console.log('- Render timed out; falling back to client-side rendering')
+        librato.increment('webapp-server-render-timeout')
+        res.send(indexStr)
+        job.removeListener('complete', jobCompleteCallback)
+        job.removeListener('failed', jobFailedCallback)
+      }, preRenderTimeout)
+
+      job.on('complete', jobCompleteCallback)
+      job.on('failed', jobFailedCallback)
+    })
   })
 }
 


### PR DESCRIPTION
Previously we could end up in a situation where multiple would return, and try to return multiple responses. This fixes that.