### PR TITLE
Pull webpack hash into the filename

### DIFF
--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -66,8 +66,8 @@ const indexStr = fs.readFileSync(path.join(__dirname, '../public/index.html'), '
 addOauthRoute(app)
 
 // Assets
-app.use(express.static('public', { maxAge: '1y', index: false }))
-app.use('/static', express.static('public/static', { maxAge: '1y' }))
+app.use(express.static('public', { index: false, redirect: false }))
+app.use('/static', express.static('public/static', { maxAge: '1y', index: false, redirect: false }))
 
 function saveResponseToCache(cacheKey, body) {
   memcacheClient.set(cacheKey, body, (err) => {

--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -67,7 +67,7 @@ addOauthRoute(app)
 
 // Assets
 app.use(express.static('public', { index: false, redirect: false }))
-app.use('/static', express.static('public/static', { maxAge: '1y', index: false, redirect: false }))
+app.use('/static', express.static('public/static', { maxAge: '1y', index: false, redirect: false, fallthrough: false }))
 
 function saveResponseToCache(cacheKey, body) {
   memcacheClient.set(cacheKey, body, (err) => {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -24,8 +24,8 @@ module.exports = {
     main: './src/main',
   },
   output: {
-    filename: '[name].entry.js',
-    chunkFilename: '[id].chunk.js',
+    filename: '[name]-[hash].entry.js',
+    chunkFilename: '[id]-[chunkhash].chunk.js',
     hash: true,
     path: path.join(__dirname, 'public/static'),
     publicPath: `${(process.env.CDN || '')}/static/`,


### PR DESCRIPTION
This should help prevent cache-pollution issues when we have to roll back, as it won't allow two different versions of the same filename to be cached with different content in different POPs.