### PR TITLE
Adds svg properties to the pxtorem blacklist

### DIFF
--- a/src/vendor/glamor-pxtorem.js
+++ b/src/vendor/glamor-pxtorem.js
@@ -21,6 +21,8 @@ const blacklist = [
   'flexShrink',
   'flexOrder',
   'order',
+  'strokeMiterlimit',
+  'strokeWidth',
   'counterIncrement',
   'counterReset',
 ]


### PR DESCRIPTION
Added for `strokeMiterlimit` and `strokeWidth`

Most likely there are more of these out there. Will just keep adding to the list as they come up.

[Finishes: #141957811](https://www.pivotaltracker.com/story/show/141957811)