### PR TITLE
Updates meta attributes for the video element

### DIFF
--- a/src/components/regions/ImageRegion.js
+++ b/src/components/regions/ImageRegion.js
@@ -3,6 +3,7 @@ import Immutable from 'immutable'
 import React, { Component, PropTypes } from 'react'
 import { Link } from 'react-router'
 import classNames from 'classnames'
+import { isIOS } from '../../lib/jello'
 import ImageAsset from '../assets/ImageAsset'
 import { ElloBuyButton } from '../editor/ElloBuyButton'
 
@@ -47,7 +48,7 @@ class ImageRegion extends Component {
       const imageHeight = Number(asset.getIn(['attachment', 'original', 'metadata', 'height']))
       scale = innerHeight / imageHeight
     }
-    const isVideo = !!(asset && asset.getIn(['attachment', 'video'], Immutable.Map()).size)
+    const isVideo = !!(asset && asset.getIn(['attachment', 'video'], Immutable.Map()).size) && !isIOS()
     this.state = {
       marginBottom: null,
       scale: isNaN(scale) ? null : scale,
@@ -188,7 +189,7 @@ class ImageRegion extends Component {
   }
 
   isVideo() {
-    return this.attachment.getIn(['video'])
+    return this.attachment.getIn(['video']) && !isIOS()
   }
 
   renderGifAttachment() {

--- a/src/components/regions/ImageRegion.js
+++ b/src/components/regions/ImageRegion.js
@@ -255,9 +255,12 @@ class ImageRegion extends Component {
         autoPlay
         height={height}
         loop
-        src={this.attachment.getIn(['video', 'url'])}
+        muted
+        playsInline
         width={width}
-      />
+      >
+        <source src={this.attachment.getIn(['video', 'url'])} />
+      </video>
     )
   }
 


### PR DESCRIPTION
This doesn't seem to entirely fix the issue in the simulator but does provide some improvements. In iOS 10, [Webkit upgraded their policy on playing videos](https://webkit.org/blog/6784/new-video-policies-for-ios/) :point_left::+1::book:. This update just implements the changes they suggest.

React however, doesn't add the `muted` attribute to the dom element (though viewing the controls does show it muted). Not sure if the missing attribute is related to the issues I'm seeing in the simulator or not. There is a related [issue in react](https://github.com/facebook/react/issues/6544).

[#141788047](https://www.pivotaltracker.com/story/show/141788047)