### PR TITLE
Roll our own glamor helpers

### DIFF
--- a/src/components/assets/Icons.js
+++ b/src/components/assets/Icons.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
-import { compose } from 'glamor'
 import { SVGBox, SVGIcon } from './SVGComponents'
+import { css } from '../../styles/jss'
 import { easeInOutCubic } from '../../styles/jso'
 
 // -------------------------------------
@@ -111,7 +111,7 @@ type ArrowProps = {
   isAnimated?: boolean,
 }
 
-const arrowStrokeAnimationStyle = compose(
+const arrowStrokeAnimationStyle = css(
   { fill: '#fff' },
   { animation: `animateUploaderMover 0.666s infinite ${easeInOutCubic}` },
 )

--- a/src/components/devtools/StyleGuide.js
+++ b/src/components/devtools/StyleGuide.js
@@ -1,24 +1,24 @@
 // @flow
 import React from 'react'
-import { compose, media } from 'glamor'
 import { MainView } from '../views/MainView'
 // import StyleGuideIcons from './StyleGuideIcons'
+import { css, media } from '../../styles/jss'
 import { flex, fontSize18, fontSize24, minBreak2, mr10, pt20, pt40, py20, wrapperPaddingX } from '../../styles/jso'
 
-const headerStyle = compose(
+const headerStyle = css(
   wrapperPaddingX,
   pt20,
   media(minBreak2, pt40),
 )
-const h1Style = compose(fontSize24)
-const navStyle = compose(flex, py20)
-const buttonStyle = compose(fontSize18, mr10)
+const h1Style = css(fontSize24)
+const navStyle = css(flex, py20)
+const buttonStyle = css(fontSize18, mr10)
 
 export default() =>
   <MainView className="StyleGuide">
     <header className={headerStyle}>
       <h1 className={h1Style}>Ello style guide</h1>
-      <nav className={navStyle} >
+      <nav className={navStyle}>
         <button className={buttonStyle}>Icons</button>
       </nav>
     </header>

--- a/src/components/devtools/StyleGuideIcons.js
+++ b/src/components/devtools/StyleGuideIcons.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import { $, compose } from 'glamor'
+import { css, select } from '../../styles/jss'
 import {
   // Ello icons
   ElloMark,
@@ -59,16 +59,16 @@ import {
 } from '../assets/Icons'
 import { flex, flexColumn, flexWrap, fontSize16, mb10, mb40, mr10, my40, wrapperPaddingX } from '../../styles/jso'
 
-const sectionStyle = compose(flex, flexColumn, flexWrap, wrapperPaddingX, my40)
-const h2Style = compose(mb10, fontSize16)
-const groupStyle = compose(
+const sectionStyle = css(flex, flexColumn, flexWrap, wrapperPaddingX, my40)
+const h2Style = css(mb10, fontSize16)
+const groupStyle = css(
   flex,
   mb40,
-  $('> *', mr10),
+  select('& > *', mr10),
 )
 
 // TODO: Move to icons...
-const badgeStyle = $('& .CheckShape', { stroke: 'white' })
+const badgeStyle = select('& .CheckShape', { stroke: 'white' })
 
 export default() =>
   <section className={sectionStyle}>

--- a/src/components/editor/ImageBlock.js
+++ b/src/components/editor/ImageBlock.js
@@ -1,10 +1,10 @@
 import Immutable from 'immutable'
 import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
-import { compose } from 'glamor'
 import Block from './Block'
 import ImageAsset from '../assets/ImageAsset'
 import { ArrowIcon } from '../assets/Icons'
+import { css } from '../../styles/jss'
 import {
   absolute,
   bgcWhite,
@@ -16,7 +16,7 @@ import {
   relative,
 } from '../../styles/jso'
 
-const busyWrapperStyle = compose(
+const busyWrapperStyle = css(
   absolute,
   flood,
   flex,
@@ -25,7 +25,7 @@ const busyWrapperStyle = compose(
   { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
 )
 
-const arrowStyle = compose(
+const arrowStyle = css(
   relative,
   colorA,
   bgcWhite,

--- a/src/components/posts/PostRenderables.js
+++ b/src/components/posts/PostRenderables.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-multi-comp */
 import React, { PropTypes, PureComponent } from 'react'
-import { $, compose, hover, parent } from 'glamor'
 import { Link } from 'react-router'
 import classNames from 'classnames'
 import Avatar from '../assets/Avatar'
@@ -8,6 +7,7 @@ import { ArrowIcon, RepostIcon } from '../assets/Icons'
 import ContentWarningButton from '../posts/ContentWarningButton'
 import RelationshipContainer from '../../containers/RelationshipContainer'
 import { RegionItems } from '../regions/RegionRenderables'
+import { css, hover, select } from '../../styles/jss'
 import { absolute, colorA, colorBlack, fontSize18, transitionColor } from '../../styles/jso'
 
 const PostHeaderTimeAgoLink = ({ to, createdAt }) =>
@@ -249,14 +249,14 @@ export class PostBody extends PureComponent {
   }
 }
 
-const relatedPostButtonStyle = compose(
+const relatedPostButtonStyle = css(
   absolute,
   { top: 0, right: 0 },
   fontSize18,
   colorA,
   transitionColor,
-  parent('.no-touch', hover(colorBlack)),
-  $('> .ArrowIcon', { transform: 'rotate(90deg)', marginLeft: 15 }),
+  hover(colorBlack),
+  select('& > .ArrowIcon', { transform: 'rotate(90deg)', marginLeft: 15 }),
 )
 
 export const RelatedPostsButton = (props, { onClickScrollToRelatedPosts }) =>

--- a/src/components/views/PostDetail.js
+++ b/src/components/views/PostDetail.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react'
-import { compose } from 'glamor'
 import Editor from '../editor/Editor'
 import PostContainer from '../../containers/PostContainer'
 import StreamContainer from '../../containers/StreamContainer'
@@ -7,9 +6,10 @@ import { MainView } from '../views/MainView'
 import { loadRelatedPosts } from '../../actions/posts'
 import { RelatedPostsButton } from '../posts/PostRenderables'
 import { TabListButtons } from '../tabs/TabList'
+import { css } from '../../styles/jss'
 import { relative } from '../../styles/jso'
 
-const navStyle = compose(
+const navStyle = css(
   relative,
   { marginBottom: -10 },
 )

--- a/src/styles/jso.js
+++ b/src/styles/jso.js
@@ -1,13 +1,9 @@
 // @flow
 // JavaScript Style Objects (jso)
-import { compose, css, media } from 'glamor'
+import { css, media } from './jss'
 
 // TODO: Note web vs native properties
 // TODO: Should web only props live in cso?
-
-// -------------------------------------
-// Helpers
-export const combine = (...styles: Array<string>) => styles.join(' ')
 
 // -------------------------------------
 // Configuration
@@ -128,7 +124,7 @@ export const px40 = { ...pr40, ...pl40 }
 export const py40 = { ...pt40, ...pb40 }
 
 // Web specific
-export const wrapperPaddingX = compose(
+export const wrapperPaddingX = css(
   px10,
   media(minBreak2, px20),
   media(minBreak4, px40),

--- a/src/styles/jss.js
+++ b/src/styles/jss.js
@@ -1,0 +1,33 @@
+// @flow
+import { css } from 'glamor'
+
+type JSO = {
+  [key: string]: string | number | null,
+}
+
+export { css }
+
+export const combine = (...styles: Array<string>) =>
+  styles.join(' ')
+
+export const media = (query: string, ...styles:Array<JSO>) =>
+  css({ [`@media ${query}`]: styles })
+
+export const parent = (selector: string, ...styles:Array<JSO>) =>
+  css({ [`${selector} &`]: styles })
+
+export const modifier = (selector: string, ...styles:Array<JSO>) =>
+  css({ [`&${selector}`]: styles })
+
+export const select = (selector: string, ...styles:Array<JSO>) =>
+  css({ [selector]: styles })
+
+export const hover = (...styles:Array<JSO>) =>
+  select('.no-touch &:hover', ...styles)
+
+export const before = (...styles:Array<JSO>) =>
+  select('::before', ...styles)
+
+export const after = (...styles:Array<JSO>) =>
+  select('::after', ...styles)
+


### PR DESCRIPTION
These helpers are going away in glamor v3 and they are pretty handy. I'll most likely add more when we start converting CSS over. At some point we can probably move these to their own package.

This also sets us up to proxy all calls to glamor through `../../styles/jss`. Keep it in the family.

[#138191285](https://www.pivotaltracker.com/story/show/138191285)