### PR TITLE
Add a close button to all modals

### DIFF
--- a/src/components/assets/Icons.css
+++ b/src/components/assets/Icons.css
@@ -543,6 +543,7 @@
   position: absolute;
   top: 10px;
   right: 15px;
+  z-index: 2;
 }
 
 .no-touch .XClose:hover {

--- a/src/components/dialogs/BlockMuteDialog.css
+++ b/src/components/dialogs/BlockMuteDialog.css
@@ -13,7 +13,6 @@
   margin-bottom: 40px;
   font-size: 18px;
   line-height: 30px;
-  white-space: nowrap;
 }
 
 .BlockMuteDialogButton {

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -1,11 +1,12 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-
 import React, { PropTypes } from 'react'
 import classNames from 'classnames'
+import { XIcon } from '../assets/Icons'
 
 export const Modal = ({ classList, component, kind, isActive, onClickModal }) =>
   <div className={classNames(classList, kind, { isActive })} onClick={onClickModal}>
     {component}
+    <button className="CloseModal XClose"><XIcon /></button>
   </div>
 
 Modal.propTypes = {


### PR DESCRIPTION
This adds the button to all existing modals so users have a visual cue
on something to click on in order to dismiss a modal.

[Fixes: #141971643](https://www.pivotaltracker.com/story/show/141971643)