### PR TITLE
Update the result key of related to use token

### DIFF
--- a/src/components/posts/PostTools.css
+++ b/src/components/posts/PostTools.css
@@ -68,7 +68,7 @@
   line-height: 22px;
 }
 
-.ViewsTool.isPill > button {
+.ViewsTool.isPill > a {
   padding-right: 11px;
   padding-left: 11px;
   color: #535353;
@@ -77,13 +77,13 @@
   transition: color var(--speed) ease, background-color var(--speed) ease;
 }
 
-.ViewsTool.isPill > button .SVGIcon,
-.ViewsTool.isPill > button .PostToolValue {
+.ViewsTool.isPill > a .SVGIcon,
+.ViewsTool.isPill > a .PostToolValue {
   position: relative;
   top: 1px;
 }
 
-.no-touch .ViewsTool.isPill button:hover {
+.no-touch .ViewsTool.isPill a:hover {
   background-color: #ccc;
 }
 

--- a/src/components/posts/PostTools.css
+++ b/src/components/posts/PostTools.css
@@ -68,7 +68,7 @@
   line-height: 22px;
 }
 
-.ViewsTool.isPill > a {
+.ViewsTool.isPill > button {
   padding-right: 11px;
   padding-left: 11px;
   color: #535353;
@@ -77,13 +77,13 @@
   transition: color var(--speed) ease, background-color var(--speed) ease;
 }
 
-.ViewsTool.isPill > a .SVGIcon,
-.ViewsTool.isPill > a .PostToolValue {
+.ViewsTool.isPill > button .SVGIcon,
+.ViewsTool.isPill > button .PostToolValue {
   position: relative;
   top: 1px;
 }
 
-.no-touch .ViewsTool.isPill a:hover {
+.no-touch .ViewsTool.isPill button:hover {
   background-color: #ccc;
 }
 

--- a/src/components/posts/PostTools.js
+++ b/src/components/posts/PostTools.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-multi-comp */
 import React, { PropTypes, PureComponent } from 'react'
 import classNames from 'classnames'
+import { Link } from 'react-router'
 import { numberToHuman } from '../../lib/number_to_human'
 import Hint from '../hints/Hint'
 import {
@@ -17,21 +18,22 @@ import {
 
 class ViewsTool extends PureComponent {
   static propTypes = {
+    detailPath: PropTypes.string.isRequired,
     isLoggedIn: PropTypes.bool.isRequired,
     postViewsCountRounded: PropTypes.string.isRequired,
   }
   static contextTypes = {
-    onGoToDetail: PropTypes.func.isRequired,
+    onTrackRelatedPostClick: PropTypes.func.isRequired,
   }
   render() {
-    const { isLoggedIn, postViewsCountRounded } = this.props
+    const { detailPath, isLoggedIn, postViewsCountRounded } = this.props
     return (
       <span className={classNames('PostTool', 'ViewsTool', { isPill: isLoggedIn })}>
-        <button onClick={this.context.onGoToDetail}>
+        <Link to={detailPath} onClick={this.context.onTrackRelatedPostClick}>
           <EyeIcon />
           <span className="PostToolValue">{postViewsCountRounded}</span>
           <Hint>Views</Hint>
-        </button>
+        </Link>
       </span>
     )
   }
@@ -39,19 +41,20 @@ class ViewsTool extends PureComponent {
 
 class TimeAgoTool extends PureComponent {
   static propTypes = {
+    detailPath: PropTypes.string.isRequired,
     postCreatedAt: PropTypes.string.isRequired,
   }
   static contextTypes = {
-    onGoToDetail: PropTypes.func.isRequired,
+    onTrackRelatedPostClick: PropTypes.func.isRequired,
   }
   render() {
-    const { postCreatedAt } = this.props
+    const { detailPath, postCreatedAt } = this.props
     return (
       <span className="PostTool TimeAgoTool">
-        <button onClick={this.context.onGoToDetail}>
+        <Link to={detailPath} onClick={this.context.onTrackRelatedPostClick}>
           <span className="PostToolValue">{new Date(postCreatedAt).timeAgoInWords()}</span>
           <Hint>Visit</Hint>
-        </button>
+        </Link>
       </span>
     )
   }
@@ -59,33 +62,33 @@ class TimeAgoTool extends PureComponent {
 
 class CommentTool extends PureComponent {
   static propTypes = {
+    detailPath: PropTypes.string.isRequired,
     isLoggedIn: PropTypes.bool.isRequired,
     postCommentsCount: PropTypes.number.isRequired,
   }
   static contextTypes = {
     onClickToggleComments: PropTypes.func.isRequired,
-    onGoToDetail: PropTypes.func.isRequired,
+    onTrackRelatedPostClick: PropTypes.func.isRequired,
   }
   render() {
-    const { isLoggedIn, postCommentsCount } = this.props
-    const { onClickToggleComments, onGoToDetail } = this.context
+    const { detailPath, isLoggedIn, postCommentsCount } = this.props
     return (
       <span className="PostTool CommentTool" data-count={postCommentsCount} >
         {isLoggedIn ?
-          <button onClick={onClickToggleComments} >
+          <button onClick={this.context.onClickToggleComments} >
             <BubbleIcon />
             <span className="PostToolValue" >
               {numberToHuman(postCommentsCount, false)}
             </span>
             <Hint>Comment</Hint>
           </button> :
-          <button onClick={onGoToDetail}>
+          <Link to={detailPath} onClick={this.context.onTrackRelatedPostClick}>
             <BubbleIcon />
             <span className="PostToolValue" >
               {numberToHuman(postCommentsCount, false)}
             </span>
             <Hint>Comment</Hint>
-          </button>
+          </Link>
         }
       </span>
     )

--- a/src/components/posts/PostTools.js
+++ b/src/components/posts/PostTools.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 import React, { PropTypes, PureComponent } from 'react'
 import classNames from 'classnames'
-import { Link } from 'react-router'
 import { numberToHuman } from '../../lib/number_to_human'
 import Hint from '../hints/Hint'
 import {
@@ -18,19 +17,21 @@ import {
 
 class ViewsTool extends PureComponent {
   static propTypes = {
-    detailPath: PropTypes.string.isRequired,
     isLoggedIn: PropTypes.bool.isRequired,
     postViewsCountRounded: PropTypes.string.isRequired,
   }
+  static contextTypes = {
+    onGoToDetail: PropTypes.func.isRequired,
+  }
   render() {
-    const { detailPath, isLoggedIn, postViewsCountRounded } = this.props
+    const { isLoggedIn, postViewsCountRounded } = this.props
     return (
       <span className={classNames('PostTool', 'ViewsTool', { isPill: isLoggedIn })}>
-        <Link to={detailPath}>
+        <button onClick={this.context.onGoToDetail}>
           <EyeIcon />
           <span className="PostToolValue">{postViewsCountRounded}</span>
           <Hint>Views</Hint>
-        </Link>
+        </button>
       </span>
     )
   }
@@ -38,17 +39,19 @@ class ViewsTool extends PureComponent {
 
 class TimeAgoTool extends PureComponent {
   static propTypes = {
-    detailPath: PropTypes.string.isRequired,
     postCreatedAt: PropTypes.string.isRequired,
   }
+  static contextTypes = {
+    onGoToDetail: PropTypes.func.isRequired,
+  }
   render() {
-    const { detailPath, postCreatedAt } = this.props
+    const { postCreatedAt } = this.props
     return (
       <span className="PostTool TimeAgoTool">
-        <Link to={detailPath}>
+        <button onClick={this.context.onGoToDetail}>
           <span className="PostToolValue">{new Date(postCreatedAt).timeAgoInWords()}</span>
           <Hint>Visit</Hint>
-        </Link>
+        </button>
       </span>
     )
   }
@@ -56,32 +59,33 @@ class TimeAgoTool extends PureComponent {
 
 class CommentTool extends PureComponent {
   static propTypes = {
-    detailPath: PropTypes.string.isRequired,
     isLoggedIn: PropTypes.bool.isRequired,
     postCommentsCount: PropTypes.number.isRequired,
   }
   static contextTypes = {
     onClickToggleComments: PropTypes.func.isRequired,
+    onGoToDetail: PropTypes.func.isRequired,
   }
   render() {
-    const { detailPath, isLoggedIn, postCommentsCount } = this.props
+    const { isLoggedIn, postCommentsCount } = this.props
+    const { onClickToggleComments, onGoToDetail } = this.context
     return (
       <span className="PostTool CommentTool" data-count={postCommentsCount} >
         {isLoggedIn ?
-          <button onClick={this.context.onClickToggleComments} >
+          <button onClick={onClickToggleComments} >
             <BubbleIcon />
             <span className="PostToolValue" >
               {numberToHuman(postCommentsCount, false)}
             </span>
             <Hint>Comment</Hint>
           </button> :
-          <Link to={detailPath}>
+          <button onClick={onGoToDetail}>
             <BubbleIcon />
             <span className="PostToolValue" >
               {numberToHuman(postCommentsCount, false)}
             </span>
             <Hint>Comment</Hint>
-          </Link>
+          </button>
         }
       </span>
     )

--- a/src/components/views/PostDetail.js
+++ b/src/components/views/PostDetail.js
@@ -48,7 +48,7 @@ export const PostDetail = (
             />
           }
           <StreamContainer
-            action={loadRelatedPosts(post.get('id'), columnCount)}
+            action={loadRelatedPosts(`~${post.get('token')}`, columnCount)}
             className="RelatedPostsStreamContainer"
             shouldInfiniteScroll={false}
           />

--- a/src/containers/PostContainer.js
+++ b/src/containers/PostContainer.js
@@ -200,7 +200,7 @@ class PostContainer extends Component {
     onClickSharePost: PropTypes.func.isRequired,
     onClickToggleComments: PropTypes.func.isRequired,
     onClickWatchPost: PropTypes.func.isRequired,
-    onGoToDetail: PropTypes.func.isRequired,
+    onTrackRelatedPostClick: PropTypes.func.isRequired,
   }
 
   static contextTypes = {
@@ -219,7 +219,7 @@ class PostContainer extends Component {
       onClickSharePost: this.onClickSharePost,
       onClickToggleComments: this.onClickToggleComments,
       onClickWatchPost: isLoggedIn ? this.onClickWatchPost : this.onOpenSignupModal,
-      onGoToDetail: this.onGoToDetail,
+      onTrackRelatedPostClick: this.onTrackRelatedPostClick,
     }
   }
 
@@ -290,12 +290,13 @@ class PostContainer extends Component {
   }
 
   onClickRepostPost = () => {
-    const { dispatch, isRelatedPost, post, postReposted } = this.props
+    const { detailPath, dispatch, isRelatedPost, post, postReposted } = this.props
     if (!postReposted && !isRelatedPost) {
       dispatch(toggleReposting(post, true))
       dispatch(loadEditablePost(post.get('id')))
     } else {
-      this.onGoToDetail()
+      dispatch(push(detailPath))
+      this.onTrackRelatedPostClick()
     }
   }
 
@@ -307,13 +308,14 @@ class PostContainer extends Component {
   }
 
   onClickToggleComments = () => {
-    const { dispatch, isLoggedIn, isRelatedPost, post, showCommentEditor } = this.props
+    const { detailPath, dispatch, isLoggedIn, isRelatedPost, post, showCommentEditor } = this.props
     if (isLoggedIn && !isRelatedPost) {
       const nextShowComments = !showCommentEditor
       this.setState({ isCommentsActive: nextShowComments })
       dispatch(toggleComments(post, nextShowComments))
     } else {
-      this.onGoToDetail()
+      dispatch(push(detailPath))
+      this.onTrackRelatedPostClick()
     }
   }
 
@@ -359,7 +361,8 @@ class PostContainer extends Component {
         return
       }
       // ..otherwise just push it through..
-      this.onGoToDetail()
+      dispatch(push(detailPath))
+      this.onTrackRelatedPostClick()
     }
     // The alternative is it's either in list and we ignore it or it's an
     // absolute link and we allow it's default behavior.
@@ -370,9 +373,8 @@ class PostContainer extends Component {
     dispatch(closeModal())
   }
 
-  onGoToDetail = () => {
-    const { detailPath, dispatch, isRelatedPost } = this.props
-    dispatch(push(detailPath))
+  onTrackRelatedPostClick = () => {
+    const { dispatch, isRelatedPost } = this.props
     if (isRelatedPost) { dispatch(trackEvent('related_post_clicked')) }
   }
 

--- a/src/containers/PostContainer.js
+++ b/src/containers/PostContainer.js
@@ -200,6 +200,7 @@ class PostContainer extends Component {
     onClickSharePost: PropTypes.func.isRequired,
     onClickToggleComments: PropTypes.func.isRequired,
     onClickWatchPost: PropTypes.func.isRequired,
+    onGoToDetail: PropTypes.func.isRequired,
   }
 
   static contextTypes = {
@@ -218,6 +219,7 @@ class PostContainer extends Component {
       onClickSharePost: this.onClickSharePost,
       onClickToggleComments: this.onClickToggleComments,
       onClickWatchPost: isLoggedIn ? this.onClickWatchPost : this.onOpenSignupModal,
+      onGoToDetail: this.onGoToDetail,
     }
   }
 
@@ -288,12 +290,12 @@ class PostContainer extends Component {
   }
 
   onClickRepostPost = () => {
-    const { detailPath, dispatch, isRelatedPost, post, postReposted } = this.props
+    const { dispatch, isRelatedPost, post, postReposted } = this.props
     if (!postReposted && !isRelatedPost) {
       dispatch(toggleReposting(post, true))
       dispatch(loadEditablePost(post.get('id')))
     } else {
-      dispatch(push(detailPath))
+      this.onGoToDetail()
     }
   }
 
@@ -305,13 +307,13 @@ class PostContainer extends Component {
   }
 
   onClickToggleComments = () => {
-    const { detailPath, dispatch, isLoggedIn, isRelatedPost, post, showCommentEditor } = this.props
+    const { dispatch, isLoggedIn, isRelatedPost, post, showCommentEditor } = this.props
     if (isLoggedIn && !isRelatedPost) {
       const nextShowComments = !showCommentEditor
       this.setState({ isCommentsActive: nextShowComments })
       dispatch(toggleComments(post, nextShowComments))
     } else {
-      dispatch(push(detailPath))
+      this.onGoToDetail()
     }
   }
 
@@ -357,7 +359,7 @@ class PostContainer extends Component {
         return
       }
       // ..otherwise just push it through..
-      dispatch(push(detailPath))
+      this.onGoToDetail()
     }
     // The alternative is it's either in list and we ignore it or it's an
     // absolute link and we allow it's default behavior.
@@ -366,6 +368,12 @@ class PostContainer extends Component {
   onCloseModal = () => {
     const { dispatch } = this.props
     dispatch(closeModal())
+  }
+
+  onGoToDetail = () => {
+    const { detailPath, dispatch, isRelatedPost } = this.props
+    dispatch(push(detailPath))
+    if (isRelatedPost) { dispatch(trackEvent('related_post_clicked')) }
   }
 
   onOpenSignupModal = () => {

--- a/src/containers/PostDetailContainer.js
+++ b/src/containers/PostDetailContainer.js
@@ -74,7 +74,7 @@ class PostDetailContainer extends Component {
     const token = `~${params.token}`
     return Promise.all([
       store.dispatch(loadPostDetail(token, `~${params.username}`)),
-      store.dispatch(loadRelatedPosts(token, 2)),
+      store.dispatch(loadRelatedPosts(token, 3)),
     ])
   }
 


### PR DESCRIPTION
The result keys were different when it was trying to actually render so
iso couldn't find the posts to drop into the page. Also bumped the
number of related posts loaded during iso to 3.

[Fixes #141882137](https://www.pivotaltracker.com/story/show/141882137)