### PR TITLE
Move dismiss buttons to the dialog from the modal

### DIFF
--- a/src/components/assets/Icons.css
+++ b/src/components/assets/Icons.css
@@ -548,22 +548,5 @@
   color: #ababab;
 }
 
-.XClose {
-  position: absolute;
-  top: 10px;
-  right: 15px;
-  z-index: 2;
-}
-
-.no-touch .XClose:hover {
-  color: #000;
-}
-
-@media (--break-2) {
-  .XClose {
-    top: 20px;
-    right: 25px;
-  }
-}
-
 /* stylelint-enable selector-max-compound-selectors, selector-max-specificity */
+

--- a/src/components/buttons/Buttons.js
+++ b/src/components/buttons/Buttons.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
-import { css, hover } from '../../styles/jss'
+import { XIcon } from '../assets/Icons'
+import { css, hover, media } from '../../styles/jss'
 import * as s from '../../styles/jso'
 
 const miniPillStyle = css(
@@ -46,4 +47,18 @@ MiniPillLink.propTypes = {
   children: PropTypes.node.isRequired,
   to: PropTypes.string.isRequired,
 }
+
+// -------------------------------------
+
+const dismissButtonStyle = css(
+  s.absolute,
+  { top: 5, right: 5 },
+  s.zIndex2,
+  s.transitionColor,
+  hover(s.colorA),
+  media(s.minBreak2, { top: 10, right: 10 }),
+)
+
+export const DismissButton = (...elementProps) =>
+  <button className={`CloseModal ${dismissButtonStyle}`} {...elementProps}><XIcon /></button>
 

--- a/src/components/dialogs/AdultPostsDialog.js
+++ b/src/components/dialogs/AdultPostsDialog.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import { DismissButton } from '../../components/buttons/Buttons'
 import { css, hover, media } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import { dialogStyle as baseDialogStyle } from './Dialog'
@@ -34,6 +35,7 @@ const AdultPostsDialog = ({ onConfirm }) =>
       adult content will not see your posts.
     </p>
     <button className={buttonStyle} onClick={onConfirm}>Okay</button>
+    <DismissButton />
   </div>
 
 AdultPostsDialog.propTypes = {

--- a/src/components/dialogs/BlockMuteDialog.js
+++ b/src/components/dialogs/BlockMuteDialog.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import classNames from 'classnames'
+import { DismissButton } from '../../components/buttons/Buttons'
 import { css, hover, media, modifier } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import { dialogStyle as baseDialogStyle } from './Dialog'
@@ -76,6 +77,7 @@ const BlockMuteDialog = ({
           </p>
         </div>
       </div>
+      <DismissButton />
     </div>
   )
 }

--- a/src/components/dialogs/Dialog.js
+++ b/src/components/dialogs/Dialog.js
@@ -8,6 +8,8 @@ export const dialogStyle = css(
   select('.Modal > &', s.p10, s.my0, s.mxAuto, media(s.minBreak2, s.p20), media(s.minBreak4, s.p40)),
 )
 
+// TODO: This shows up in an alert which is sort of werid so we hardcode this
+// button instead of using the dismiss
 const dismissStyle = css(s.absolute, { top: -10, right: -10 }, s.colorWhite, hover(s.colorA))
 
 const Dialog = ({ body, title, onClick }) =>

--- a/src/components/dialogs/DialogRenderables.js
+++ b/src/components/dialogs/DialogRenderables.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-danger */
 import React, { PropTypes } from 'react'
-import { XIcon } from '../assets/Icons'
-import { css, hover, media, select } from '../../styles/jss'
+import { DismissButton } from '../../components/buttons/Buttons'
+import { css, select } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import { dialogStyle as baseDialogStyle } from './Dialog'
 
@@ -12,17 +12,10 @@ const textDialogStyle = css(
   select('& a', s.fontSize18),
 )
 
-const dismissStyle = css(
-  s.fixed,
-  { top: 5, right: 5 },
-  hover(s.colorA),
-  media(s.minBreak2, { top: 10, right: 10 }),
-)
-
 export const TextMarkupDialog = ({ html }) =>
   <div className={`${baseDialogStyle} ${textDialogStyle}`}>
     <div dangerouslySetInnerHTML={{ __html: html }} />
-    <button className={`CloseModal ${dismissStyle}`}><XIcon /></button>
+    <DismissButton />
   </div>
 
 TextMarkupDialog.propTypes = {
@@ -35,6 +28,7 @@ const featuredDialogStyle = css(s.fontSize18, select('& a', s.borderBottom, { li
 export const FeaturedInDialog = ({ children }) =>
   <div className={`${baseDialogStyle} ${featuredDialogStyle}`}>
     {children}
+    <DismissButton />
   </div>
 FeaturedInDialog.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/components/dialogs/FlagDialog.js
+++ b/src/components/dialogs/FlagDialog.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
+import { DismissButton } from '../../components/buttons/Buttons'
 import { before, css, hover, media, modifier, select } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import { dialogStyle as baseDialogStyle } from './Dialog'
@@ -140,6 +141,7 @@ export default class FlagDialog extends Component {
           marked NSFW. You may temporarily still see this content. You may want
           to block or mute this user as well.
         </p>
+        <DismissButton />
       </div>
     )
   }
@@ -156,6 +158,7 @@ export default class FlagDialog extends Component {
         <div>
           <button className={okayButtonStyle} onClick={onConfirm}>Okay</button>
         </div>
+        <DismissButton />
       </div>
     )
   }

--- a/src/components/dialogs/HelpDialog.js
+++ b/src/components/dialogs/HelpDialog.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import React from 'react'
 import { SHORTCUT_KEYS } from '../../constants/application_types'
+import { DismissButton } from '../../components/buttons/Buttons'
 import { css, media } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import { dialogStyle as baseDialogStyle } from './Dialog'
@@ -43,6 +44,7 @@ const HelpDialog = () =>
     <p className={textWrapperStyle}><span className={`${textStyle} ${s.monoRegularCSS}`}>{SHORTCUT_KEYS.DT_GRID_TOGGLE}</span> Toggle layout grid</p>
     <p className={textWrapperStyle}><span className={`${textStyle} ${s.monoRegularCSS}`}>{SHORTCUT_KEYS.DT_GRID_CYCLE}</span> Toggle between horizontal and vertical grid</p>
     <p className={textWrapperStyle}><span className={`${textStyle} ${s.monoRegularCSS}`}>{SHORTCUT_KEYS.HELP}</span> Show this help modal</p>
+    <DismissButton />
   </div>
 
 export default HelpDialog

--- a/src/components/dialogs/MessageDialog.js
+++ b/src/components/dialogs/MessageDialog.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, PureComponent } from 'react'
 import FormControl from '../forms/FormControl'
 import { CheckIconLG } from '../assets/Icons'
+import { DismissButton } from '../../components/buttons/Buttons'
 import { hireUser } from '../../networking/api'
 import { css, disabled, focus, hover, media, select } from '../../styles/jss'
 import * as s from '../../styles/jso'
@@ -106,6 +107,7 @@ export default class MessageDialog extends PureComponent {
         >
           Cancel
         </button>
+        <DismissButton />
       </div>
     )
   }
@@ -124,6 +126,7 @@ export default class MessageDialog extends PureComponent {
         >
           Okay
         </button>
+        <DismissButton />
       </div>
     )
   }

--- a/src/components/dialogs/RegistrationRequestDialog.js
+++ b/src/components/dialogs/RegistrationRequestDialog.js
@@ -2,7 +2,7 @@ import React, { PropTypes, PureComponent } from 'react'
 import RegistrationRequestForm from '../../components/forms/RegistrationRequestForm'
 import { HeroPromotionCredits } from '../../components/heros/HeroParts'
 import BackgroundImage from '../../components/assets/BackgroundImage'
-import { XIcon } from '../../components/assets/Icons'
+import { DismissButton } from '../../components/buttons/Buttons'
 
 class RegistrationRequestDialog extends PureComponent {
 
@@ -22,7 +22,7 @@ class RegistrationRequestDialog extends PureComponent {
         />
         <RegistrationRequestForm inModal />
         <HeroPromotionCredits sources={promotional.get('avatar')} label="Posted by" username={promotional.get('username')} />
-        <button className="CloseModal XClose"><XIcon /></button>
+        <DismissButton />
       </div>
     )
   }

--- a/src/components/dialogs/ShareDialog.js
+++ b/src/components/dialogs/ShareDialog.js
@@ -10,6 +10,7 @@ import {
   TumblrIcon,
   TwitterIcon,
 } from '../assets/Icons'
+import { DismissButton } from '../../components/buttons/Buttons'
 import { css, focus, hover, media } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import { dialogStyle as baseDialogStyle } from './Dialog'
@@ -180,6 +181,7 @@ class ShareDialog extends PureComponent {
           <button className={linkStyle} data-type={SHARE_TYPES.REDDIT} onClick={this.onClickOpenShareWindow}><RedditIcon /></button>
           <button className={linkStyle} data-type={SHARE_TYPES.LINKEDIN} onClick={this.onClickOpenShareWindow}><LinkedInIcon /></button>
         </div>
+        <DismissButton />
       </div>
     )
   }

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -1,12 +1,10 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { PropTypes } from 'react'
 import classNames from 'classnames'
-import { XIcon } from '../assets/Icons'
 
 export const Modal = ({ classList, component, kind, isActive, onClickModal }) =>
   <div className={classNames(classList, kind, { isActive })} onClick={onClickModal}>
     {component}
-    <button className="CloseModal XClose"><XIcon /></button>
   </div>
 
 Modal.propTypes = {


### PR DESCRIPTION
This does not add the dismiss button when the text "Cancel" appears. Seemed redundant in a few of the simple dialogs like Confirm.

[Finishes: #142644241](https://www.pivotaltracker.com/story/show/142644241)