### PR TITLE
Centralizing our tracking code in middleware

### DIFF
--- a/src/actions/modals.js
+++ b/src/actions/modals.js
@@ -1,6 +1,6 @@
 import { MODAL, ALERT } from '../constants/action_types'
 
-export function openModal(component, classList = '', type = null) {
+export function openModal(component, classList = '', type = null, trackLabel = null) {
   return {
     type: MODAL.OPEN,
     payload: {
@@ -8,6 +8,7 @@ export function openModal(component, classList = '', type = null) {
       component,
       isActive: true,
       kind: 'Modal',
+      trackLabel,
       type,
     },
   }
@@ -26,7 +27,7 @@ export function closeModal() {
   }
 }
 
-export function openAlert(component, classList = '', type = null) {
+export function openAlert(component, classList = '', type = null, trackLabel = null) {
   return {
     type: ALERT.OPEN,
     payload: {
@@ -34,6 +35,7 @@ export function openAlert(component, classList = '', type = null) {
       component,
       isActive: true,
       kind: 'Alert',
+      trackLabel,
       type,
     },
   }

--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -6,8 +6,6 @@ import * as api from '../networking/api'
 import * as StreamFilters from '../components/streams/StreamFilters'
 import * as StreamRenderables from '../components/streams/StreamRenderables'
 import { ErrorState } from '../components/errors/Errors'
-import { trackEvent } from '../actions/analytics'
-import store from '../store'
 
 export function autoCompleteLocation(location) {
   return {
@@ -46,10 +44,7 @@ export function signUpUser(email, username, password, invitationCode) {
   return {
     type: PROFILE.SIGNUP,
     meta: {
-      successAction: () => {
-        store.dispatch(replace({ pathname: '/onboarding/categories' }))
-        store.dispatch(trackEvent('join-successful'))
-      },
+      successAction: replace({ pathname: '/onboarding/categories' }),
     },
     payload: {
       method: 'POST',

--- a/src/components/editor/BlockCollection.js
+++ b/src/components/editor/BlockCollection.js
@@ -14,7 +14,6 @@ import QuickEmoji from './QuickEmoji'
 import RepostBlock from './RepostBlock'
 import TextBlock from './TextBlock'
 import PostActionBar from './PostActionBar'
-import { trackEvent } from '../../actions/analytics'
 import {
   addBlock,
   addDragBlock,
@@ -363,12 +362,8 @@ class BlockCollection extends PureComponent {
   }
 
   submit = () => {
-    const { buyLink, dispatch, submitAction } = this.props
-    const data = this.serialize()
-    if (buyLink && buyLink.length) {
-      dispatch(trackEvent('added_buy_button'))
-    }
-    submitAction(data)
+    const { submitAction } = this.props
+    submitAction(this.serialize())
   }
 
   serialize() {

--- a/src/components/editor/Editor.js
+++ b/src/components/editor/Editor.js
@@ -134,7 +134,6 @@ class Editor extends Component {
         dispatch(updateComment(comment, data, this.getEditorIdentifier()))
       } else {
         dispatch(createComment(allowsAutoWatch, data, this.getEditorIdentifier(), post.get('id')))
-        dispatch(trackEvent('published_comment'))
       }
     } else if (isPostEmpty) {
       dispatch(closeOmnibar())
@@ -143,7 +142,6 @@ class Editor extends Component {
     } else if (post.get('isEditing')) {
       dispatch(toggleEditing(post, false))
       dispatch(updatePost(post, data, this.getEditorIdentifier()))
-      dispatch(trackEvent('edited_post'))
     } else if (post.get('isReposting')) {
       dispatch(toggleReposting(post, false))
       const repostId = post.get('repostId') || post.get('id')

--- a/src/components/editor/Editor.js
+++ b/src/components/editor/Editor.js
@@ -2,11 +2,7 @@ import Immutable from 'immutable'
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { selectIsLoggedIn } from '../../selectors/authentication'
-import {
-  selectHasAutoWatchEnabled,
-  selectIsOwnPage,
-  selectProfileIsFeatured,
-} from '../../selectors/profile'
+import { selectHasAutoWatchEnabled, selectIsOwnPage } from '../../selectors/profile'
 import {
   selectPost,
   selectPostIsEditing,
@@ -14,7 +10,6 @@ import {
   selectPostIsOwn,
   selectPostIsReposting,
 } from '../../selectors/post'
-import { trackEvent } from '../../actions/analytics'
 import { openModal, closeModal } from '../../actions/modals'
 import {
   createComment,
@@ -56,7 +51,6 @@ function mapStateToProps(state, props) {
   return {
     allowsAutoWatch: selectHasAutoWatchEnabled(state),
     isLoggedIn: selectIsLoggedIn(state),
-    isFeatured: selectProfileIsFeatured(state),
     isPostEditing: selectPostIsEditing(state, props),
     isPostEmpty: selectPostIsEmpty(state, props),
     isPostReposting: selectPostIsReposting(state, props),
@@ -74,7 +68,6 @@ class Editor extends Component {
     comment: PropTypes.object,
     dispatch: PropTypes.func.isRequired,
     isComment: PropTypes.bool,
-    isFeatured: PropTypes.bool,
     isLoggedIn: PropTypes.bool,
     isOwnPage: PropTypes.bool,
     isOwnPost: PropTypes.bool,
@@ -92,7 +85,6 @@ class Editor extends Component {
     autoPopulate: null,
     comment: null,
     isComment: false,
-    isFeatured: false,
     isLoggedIn: false,
     isOwnPage: false,
     isOwnPost: false,
@@ -122,7 +114,6 @@ class Editor extends Component {
       comment,
       dispatch,
       isComment,
-      isFeatured,
       isOwnPage,
       isPostEmpty,
       onSubmit,
@@ -138,7 +129,6 @@ class Editor extends Component {
     } else if (isPostEmpty) {
       dispatch(closeOmnibar())
       dispatch(createPost(data, this.getEditorIdentifier()))
-      dispatch(trackEvent('published_post', { isFeatured }))
     } else if (post.get('isEditing')) {
       dispatch(toggleEditing(post, false))
       dispatch(updatePost(post, data, this.getEditorIdentifier()))
@@ -149,7 +139,6 @@ class Editor extends Component {
       dispatch(createPost(data, this.getEditorIdentifier(),
         repostId, repostedFromId),
       )
-      dispatch(trackEvent('published_repost', { isFeatured }))
     }
     if (onSubmit) { onSubmit() }
     // if on own page scroll down to top of post content

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -137,8 +137,8 @@ class AppContainer extends Component {
       <RegistrationRequestDialog promotional={authPromo} />,
       'asDecapitated',
       'RegistrationRequestDialog',
+      `open-registration-request-${trackPostfix}`,
     ))
-    dispatch(trackEvent(`open-registration-request-${trackPostfix}`))
     dispatch(setSignupModalLaunched())
   }
 

--- a/src/containers/CommentContainer.js
+++ b/src/containers/CommentContainer.js
@@ -2,7 +2,6 @@ import Immutable from 'immutable'
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { EDITOR } from '../constants/action_types'
-import { trackEvent } from '../actions/analytics'
 import { deleteComment, flagComment, loadEditableComment, toggleEditing } from '../actions/comments'
 import { openModal, closeModal } from '../actions/modals'
 import { selectIsLoggedIn } from '../selectors/authentication'
@@ -138,7 +137,6 @@ class CommentContainer extends Component {
     const { comment, dispatch } = this.props
     this.onCloseModal()
     dispatch(deleteComment(comment))
-    dispatch(trackEvent('deleted_comment'))
   }
 
   onClickEditComment = () => {

--- a/src/containers/HeroContainer.js
+++ b/src/containers/HeroContainer.js
@@ -190,8 +190,7 @@ class HeroContainer extends Component {
   onClickShareProfile = () => {
     const { dispatch, username } = this.props
     const action = bindActionCreators(trackEvent, dispatch)
-    dispatch(openModal(<ShareDialog username={username} trackEvent={action} />))
-    dispatch(trackEvent('open-share-dialog-profile'))
+    dispatch(openModal(<ShareDialog username={username} trackEvent={action} />, '', null, 'open-share-dialog-profile'))
   }
 
   onDismissBroadcast = () => {

--- a/src/containers/OmnibarContainer.js
+++ b/src/containers/OmnibarContainer.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 import Mousetrap from 'mousetrap'
 import { SHORTCUT_KEYS } from '../constants/application_types'
 import { selectAvatar } from '../selectors/profile'
-import { trackEvent } from '../actions/analytics'
 import { closeOmnibar } from '../actions/omnibar'
 import { Omnibar } from '../components/omnibar/Omnibar'
 
@@ -37,12 +36,6 @@ class OmnibarContainer extends Component {
 
   componentDidMount() {
     Mousetrap.bind(SHORTCUT_KEYS.FULLSCREEN, () => { this.onToggleFullScreen() })
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (!this.props.isActive && nextProps.isActive) {
-      this.props.dispatch(trackEvent('opened_omnibar'))
-    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/containers/OnboardingCategoriesContainer.js
+++ b/src/containers/OnboardingCategoriesContainer.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
 import OnboardingCategories from '../components/onboarding/OnboardingCategories'
 import { ONBOARDING_VERSION } from '../constants/application_types'
-import { trackEvent } from '../actions/analytics'
 import { getCategories } from '../actions/discover'
 import { followCategories, saveProfile, splitFinish } from '../actions/profile'
 import { selectOnboardingCategoriesFiltered } from '../selectors/categories'
@@ -72,8 +71,6 @@ class OnboardingCategoriesContainer extends PureComponent {
     const { dispatch } = this.props
     const categoryIds = this.state.categoryIds
     dispatch(saveProfile({ web_onboarding_version: ONBOARDING_VERSION }))
-    dispatch(trackEvent('Onboarding.Settings.Categories.Completed',
-                        { categories: categoryIds.length }))
     dispatch(followCategories(categoryIds))
     dispatch(push('/onboarding/settings'))
   }

--- a/src/containers/PostContainer.js
+++ b/src/containers/PostContainer.js
@@ -255,7 +255,6 @@ class PostContainer extends Component {
       set(action, 'meta.successAction', replace(previousPath || '/'))
     }
     dispatch(action)
-    dispatch(trackEvent('deleted_post'))
   }
 
   onClickEditPost = () => {
@@ -285,7 +284,6 @@ class PostContainer extends Component {
       dispatch(unlovePost(post))
     } else {
       dispatch(lovePost(post))
-      dispatch(trackEvent('web_production.post_actions_love'))
     }
   }
 
@@ -323,10 +321,8 @@ class PostContainer extends Component {
     const { dispatch, post, isWatchingPost } = this.props
     if (isWatchingPost) {
       dispatch(unwatchPost(post))
-      dispatch(trackEvent('unwatched-post'))
     } else {
       dispatch(watchPost(post))
-      dispatch(trackEvent('watched-post'))
     }
   }
 

--- a/src/containers/PostContainer.js
+++ b/src/containers/PostContainer.js
@@ -301,8 +301,7 @@ class PostContainer extends Component {
   onClickSharePost = () => {
     const { author, dispatch, post } = this.props
     const action = bindActionCreators(trackEvent, dispatch)
-    dispatch(openModal(<ShareDialog author={author} post={post} trackEvent={action} />))
-    dispatch(trackEvent('open-share-dialog'))
+    dispatch(openModal(<ShareDialog author={author} post={post} trackEvent={action} />, '', null, 'open-share-dialog'))
   }
 
   onClickToggleComments = () => {

--- a/src/containers/RelationshipContainer.js
+++ b/src/containers/RelationshipContainer.js
@@ -8,7 +8,6 @@ import { selectIsLoggedIn } from '../selectors/authentication'
 import { selectDeviceSize } from '../selectors/gui'
 import { selectPathname, selectPreviousPath } from '../selectors/routing'
 import { selectUserId, selectUserRelationshipPriority, selectUserUsername } from '../selectors/user'
-import { trackEvent } from '../actions/analytics'
 import { openModal, closeModal } from '../actions/modals'
 import { updateRelationship } from '../actions/relationships'
 import { flagUser } from '../actions/user'
@@ -159,31 +158,12 @@ class RelationshipContainer extends PureComponent {
   onRelationshipUpdate = ({ userId, priority, existing }) => {
     const { dispatch, pathname } = this.props
     const isInternal = !!(pathname && (/^\/onboarding/).test(pathname))
-    this.trackRelationshipUpdate(priority)
     dispatch(updateRelationship(userId, priority, existing, isInternal))
   }
 
   onUserWasFlagged = ({ flag }) => {
     const { dispatch, username } = this.props
     dispatch(flagUser(username, flag))
-  }
-
-  trackRelationshipUpdate = (priority) => {
-    const { dispatch } = this.props
-    switch (priority) {
-      case RELATIONSHIP_PRIORITY.FRIEND:
-      case RELATIONSHIP_PRIORITY.NOISE:
-        return dispatch(trackEvent('followed_user'))
-      case RELATIONSHIP_PRIORITY.INACTIVE:
-      case RELATIONSHIP_PRIORITY.NONE:
-        return dispatch(trackEvent('unfollowed_user'))
-      case RELATIONSHIP_PRIORITY.BLOCK:
-        return dispatch(trackEvent('blocked_user'))
-      case RELATIONSHIP_PRIORITY.MUTE:
-        return dispatch(trackEvent('muted_user'))
-      default:
-        return null
-    }
   }
 
   render() {

--- a/src/containers/SettingsContainer.js
+++ b/src/containers/SettingsContainer.js
@@ -49,7 +49,6 @@ import InfoForm from '../components/forms/InfoForm'
 import { MainView } from '../components/views/MainView'
 import { isElloAndroid } from '../lib/jello'
 import { profilePath } from '../networking/api'
-import { trackEvent } from '../actions/analytics'
 
 function getOriginalAssetUrl(asset) {
   return (
@@ -229,7 +228,6 @@ class SettingsContainer extends PureComponent {
   onConfirmAccountWasDeleted = () => {
     const { dispatch } = this.props
     dispatch(deleteProfile())
-    dispatch(trackEvent('user-deleted-account'))
   }
 
   onSubmit = (e) => {

--- a/src/containers/UserContainer.js
+++ b/src/containers/UserContainer.js
@@ -46,7 +46,6 @@ import { closeModal, openModal } from '../actions/modals'
 import { trackEvent } from '../actions/analytics'
 import { inviteUsers } from '../actions/invitations'
 import { collabWithUser, hireUser } from '../actions/user'
-import { getElloPlatform } from '../lib/jello'
 
 export function makeMapStateToProps() {
   return (state, props) => {
@@ -201,8 +200,7 @@ class UserContainer extends Component {
   onClickShareProfile = () => {
     const { dispatch, username } = this.props
     const action = bindActionCreators(trackEvent, dispatch)
-    dispatch(openModal(<ShareDialog username={username} trackEvent={action} />))
-    dispatch(trackEvent('open-share-dialog-profile'))
+    dispatch(openModal(<ShareDialog username={username} trackEvent={action} />, '', null, 'open-share-dialog-profile'))
   }
 
   onClickOpenFeaturedModal = () => {
@@ -232,14 +230,15 @@ class UserContainer extends Component {
         onDismiss={this.onDismissModal}
         titlePrefix="Collaborate with"
       />,
+      '',
+      null,
+      'open-collab-dialog-profile',
     ))
-    dispatch(trackEvent('open-collab-dialog-profile', { platform: getElloPlatform() }))
   }
 
   onConfirmCollab = ({ message }) => {
     const { dispatch, id } = this.props
     dispatch(collabWithUser(id, message))
-    dispatch(trackEvent('send-collab-dialog-profile', { platform: getElloPlatform() }))
   }
 
   onOpenHireMeModal = () => {
@@ -251,14 +250,15 @@ class UserContainer extends Component {
         onDismiss={this.onDismissModal}
         titlePrefix="Hire"
       />,
+      '',
+      null,
+      'open-hire-dialog-profile',
     ))
-    dispatch(trackEvent('open-hire-dialog-profile', { platform: getElloPlatform() }))
   }
 
   onConfirmHireMe = ({ message }) => {
     const { dispatch, id } = this.props
     dispatch(hireUser(id, message))
-    dispatch(trackEvent('send-hire-dialog-profile', { platform: getElloPlatform() }))
   }
 
   onDismissModal = () => {

--- a/src/lib/jello.js
+++ b/src/lib/jello.js
@@ -67,10 +67,6 @@ export function isIE11() {
   return memoizedIsIE11
 }
 
-export function getElloPlatform() {
-  return isElloAndroid() ? 'ello-android-app' : 'ello-webapp'
-}
-
 // -------------------------------------
 
 export function addFeatureDetection() {

--- a/src/sagas/analytics.js
+++ b/src/sagas/analytics.js
@@ -34,35 +34,27 @@ function* trackEvents() {
     const method = get(action, 'payload.method')
     switch (action.type) {
       case ACTION_TYPES.COMMENT.CREATE_REQUEST:
-        put(trackEventAction('published_comment'))
-        break
+        return yield put(trackEventAction('published_comment'))
       case ACTION_TYPES.COMMENT.DELETE_REQUEST:
-        put(trackEventAction('deleted_comment'))
-        break
+        return yield put(trackEventAction('deleted_comment'))
       case ACTION_TYPES.POST.DELETE_REQUEST:
-        put(trackEventAction('deleted_post'))
-        break
+        return yield put(trackEventAction('deleted_post'))
       case ACTION_TYPES.POST.LOVE_REQUEST:
         if (method === 'POST') {
-          put(trackEventAction('web_production.post_actions_love'))
+          return yield put(trackEventAction('web_production.post_actions_love'))
         }
         break
       case ACTION_TYPES.POST.WATCH_REQUEST:
         if (method === 'DELETE') {
-          put(trackEventAction('unwatched-post'))
-          break
+          return yield put(trackEventAction('unwatched-post'))
         }
-        put(trackEventAction('watched-post'))
-        break
+        return yield put(trackEventAction('watched-post'))
       case ACTION_TYPES.POST.UPDATE_REQUEST:
-        put(trackEventAction('edited_post'))
-        break
+        return yield put(trackEventAction('edited_post'))
       case ACTION_TYPES.PROFILE.DELETE_REQUEST:
-        put(trackEventAction('user-deleted-account'))
-        break
+        return yield put(trackEventAction('user-deleted-account'))
       case ACTION_TYPES.PROFILE.SIGNUP_SUCCESS:
-        put(trackEventAction('join-successful'))
-        break
+        return yield put(trackEventAction('join-successful'))
       default:
         break
     }

--- a/src/sagas/analytics.js
+++ b/src/sagas/analytics.js
@@ -33,69 +33,90 @@ function* trackEvent() {
 function* trackEvents() {
   while (true) {
     const action = yield take('*')
-    const method = get(action, 'payload.method')
-    const isFeatured = yield select(selectProfileIsFeatured)
     switch (action.type) {
       case ACTION_TYPES.ALERT.OPEN:
       case ACTION_TYPES.MODAL.OPEN:
         if (get(action, 'payload.trackLabel')) {
-          return yield put(trackEventAction(get(action, 'payload.trackLabel')))
+          yield put(trackEventAction(get(action, 'payload.trackLabel')))
         }
         break
       case ACTION_TYPES.COMMENT.CREATE_REQUEST:
-        return yield put(trackEventAction('published_comment'))
+        yield put(trackEventAction('published_comment'))
+        break
       case ACTION_TYPES.COMMENT.DELETE_REQUEST:
-        return yield put(trackEventAction('deleted_comment'))
+        yield put(trackEventAction('deleted_comment'))
+        break
       case ACTION_TYPES.OMNIBAR.OPEN:
-        return yield put(trackEventAction('opened_omnibar'))
-      case ACTION_TYPES.POST.CREATE_REQUEST:
+        yield put(trackEventAction('opened_omnibar'))
+        break
+      case ACTION_TYPES.POST.CREATE_REQUEST: {
+        const isFeatured = yield select(selectProfileIsFeatured)
         if (get(action, 'payload.body.body[0].link_url', '').length) {
           yield put(trackEventAction('added_buy_button'))
         }
-        return yield put(trackEventAction(get(action, 'meta.repostId') ? 'published_repost' : 'published_post', { isFeatured }))
+        yield put(trackEventAction(get(action, 'meta.repostId') ? 'published_repost' : 'published_post', { isFeatured }))
+        break
+      }
       case ACTION_TYPES.POST.DELETE_REQUEST:
-        return yield put(trackEventAction('deleted_post'))
-      case ACTION_TYPES.POST.LOVE_REQUEST:
+        yield put(trackEventAction('deleted_post'))
+        break
+      case ACTION_TYPES.POST.LOVE_REQUEST: {
+        const method = get(action, 'payload.method')
         if (method === 'POST') {
-          return yield put(trackEventAction('web_production.post_actions_love'))
+          yield put(trackEventAction('web_production.post_actions_love'))
         }
         break
-      case ACTION_TYPES.POST.WATCH_REQUEST:
+      }
+      case ACTION_TYPES.POST.WATCH_REQUEST: {
+        const method = get(action, 'payload.method')
         if (method === 'DELETE') {
-          return yield put(trackEventAction('unwatched-post'))
+          yield put(trackEventAction('unwatched-post'))
+          break
         }
-        return yield put(trackEventAction('watched-post'))
+        yield put(trackEventAction('watched-post'))
+        break
+      }
       case ACTION_TYPES.POST.UPDATE_REQUEST:
-        return yield put(trackEventAction('edited_post'))
+        yield put(trackEventAction('edited_post'))
+        break
       case ACTION_TYPES.PROFILE.DELETE_REQUEST:
-        return yield put(trackEventAction('user-deleted-account'))
+        yield put(trackEventAction('user-deleted-account'))
+        break
       case ACTION_TYPES.PROFILE.FOLLOW_CATEGORIES_REQUEST:
-        return yield put(trackEventAction('Onboarding.Settings.Categories.Completed',
+        yield put(trackEventAction('Onboarding.Settings.Categories.Completed',
           { categories: get(action, 'payload.body.followed_category_ids', []).length },
         ))
+        break
       case ACTION_TYPES.PROFILE.SIGNUP_SUCCESS:
-        return yield put(trackEventAction('join-successful'))
+        yield put(trackEventAction('join-successful'))
+        break
       case ACTION_TYPES.RELATIONSHIPS.UPDATE_INTERNAL:
       case ACTION_TYPES.RELATIONSHIPS.UPDATE_REQUEST:
         switch (get(action, 'payload.priority')) {
           case RELATIONSHIP_PRIORITY.FRIEND:
           case RELATIONSHIP_PRIORITY.NOISE:
-            return yield put(trackEventAction('followed_user'))
+            yield put(trackEventAction('followed_user'))
+            break
           case RELATIONSHIP_PRIORITY.INACTIVE:
           case RELATIONSHIP_PRIORITY.NONE:
-            return yield put(trackEventAction('unfollowed_user'))
+            yield put(trackEventAction('unfollowed_user'))
+            break
           case RELATIONSHIP_PRIORITY.BLOCK:
-            return yield put(trackEventAction('blocked_user'))
+            yield put(trackEventAction('blocked_user'))
+            break
           case RELATIONSHIP_PRIORITY.MUTE:
-            return yield put(trackEventAction('muted_user'))
+            yield put(trackEventAction('muted_user'))
+            break
           default:
             break
         }
         break
       case ACTION_TYPES.USER.COLLAB_WITH_REQUEST:
-        return yield put(trackEventAction('send-collab-dialog-profile'))
+        yield put(trackEventAction('send-collab-dialog-profile'))
+        break
       case ACTION_TYPES.USER.HIRE_ME_REQUEST:
-        return yield put(trackEventAction('send-hire-dialog-profile'))
+        yield put(trackEventAction('send-hire-dialog-profile'))
+        break
       default:
         break
     }

--- a/src/sagas/analytics.js
+++ b/src/sagas/analytics.js
@@ -4,8 +4,10 @@ import { LOCATION_CHANGE } from 'react-router-redux'
 import get from 'lodash/get'
 import { isElloAndroid } from '../lib/jello'
 import * as ACTION_TYPES from '../constants/action_types'
+import { RELATIONSHIP_PRIORITY } from '../constants/relationship_types'
 import { trackEvent as trackEventAction } from '../actions/analytics'
 import { selectActiveNotificationsType } from '../selectors/gui'
+import { selectProfileIsFeatured } from '../selectors/profile'
 
 let shouldCallInitialTrackPage = false
 const agent = isElloAndroid() ? 'android' : 'webapp'
@@ -32,11 +34,25 @@ function* trackEvents() {
   while (true) {
     const action = yield take('*')
     const method = get(action, 'payload.method')
+    const isFeatured = yield select(selectProfileIsFeatured)
     switch (action.type) {
+      case ACTION_TYPES.ALERT.OPEN:
+      case ACTION_TYPES.MODAL.OPEN:
+        if (get(action, 'payload.trackLabel')) {
+          return yield put(trackEventAction(get(action, 'payload.trackLabel')))
+        }
+        break
       case ACTION_TYPES.COMMENT.CREATE_REQUEST:
         return yield put(trackEventAction('published_comment'))
       case ACTION_TYPES.COMMENT.DELETE_REQUEST:
         return yield put(trackEventAction('deleted_comment'))
+      case ACTION_TYPES.OMNIBAR.OPEN:
+        return yield put(trackEventAction('opened_omnibar'))
+      case ACTION_TYPES.POST.CREATE_REQUEST:
+        if (get(action, 'payload.body.body[0].link_url', '').length) {
+          yield put(trackEventAction('added_buy_button'))
+        }
+        return yield put(trackEventAction(get(action, 'meta.repostId') ? 'published_repost' : 'published_post', { isFeatured }))
       case ACTION_TYPES.POST.DELETE_REQUEST:
         return yield put(trackEventAction('deleted_post'))
       case ACTION_TYPES.POST.LOVE_REQUEST:
@@ -53,8 +69,33 @@ function* trackEvents() {
         return yield put(trackEventAction('edited_post'))
       case ACTION_TYPES.PROFILE.DELETE_REQUEST:
         return yield put(trackEventAction('user-deleted-account'))
+      case ACTION_TYPES.PROFILE.FOLLOW_CATEGORIES_REQUEST:
+        return yield put(trackEventAction('Onboarding.Settings.Categories.Completed',
+          { categories: get(action, 'payload.body.followed_category_ids', []).length },
+        ))
       case ACTION_TYPES.PROFILE.SIGNUP_SUCCESS:
         return yield put(trackEventAction('join-successful'))
+      case ACTION_TYPES.RELATIONSHIPS.UPDATE_INTERNAL:
+      case ACTION_TYPES.RELATIONSHIPS.UPDATE_REQUEST:
+        switch (get(action, 'payload.priority')) {
+          case RELATIONSHIP_PRIORITY.FRIEND:
+          case RELATIONSHIP_PRIORITY.NOISE:
+            return yield put(trackEventAction('followed_user'))
+          case RELATIONSHIP_PRIORITY.INACTIVE:
+          case RELATIONSHIP_PRIORITY.NONE:
+            return yield put(trackEventAction('unfollowed_user'))
+          case RELATIONSHIP_PRIORITY.BLOCK:
+            return yield put(trackEventAction('blocked_user'))
+          case RELATIONSHIP_PRIORITY.MUTE:
+            return yield put(trackEventAction('muted_user'))
+          default:
+            break
+        }
+        break
+      case ACTION_TYPES.USER.COLLAB_WITH_REQUEST:
+        return yield put(trackEventAction('send-collab-dialog-profile'))
+      case ACTION_TYPES.USER.HIRE_ME_REQUEST:
+        return yield put(trackEventAction('send-hire-dialog-profile'))
       default:
         break
     }


### PR DESCRIPTION
Unfortunately we can't do this for all `trackEvent` calls due to the
data that needs to get passed, but it centralizes a bunch of it for now.

[#143602731](https://www.pivotaltracker.com/story/show/143602731)