### PR TITLE
Use split instead of replace to assemble iso responses

### DIFF
--- a/src/prerender.js
+++ b/src/prerender.js
@@ -165,10 +165,12 @@ function prerender(context) {
           const initialGlamTag = `<script id="glam-state">window.__GLAM__ = ${JSON.stringify(ids)}</script>`
           const initialIsoFetchesTag = `<script id="running-server-fetches">window.__ISO_FETCHES__ = ${JSON.stringify(runningServerFetches)}</script>`
           // Add helmet's stuff after the last statically rendered meta tag
-          const html = indexStr.replace(
-            'rel="copyright">',
-            `rel="copyright">${head.title.toString()} ${head.meta.toString()} ${head.link.toString()} ${timingHeader} <style>${css}</style>`,
-          ).replace('<div id="root"></div>', `<div id="root">${componentHTML}</div>${initialStateTag} ${initialGlamTag} ${initialIsoFetchesTag}`)
+          const [headTag, bodyTag] = indexStr.split('</head>')
+          const htmlWithoutRoot = `${headTag}${head.title.toString()} ${head.meta.toString()} ${head.link.toString()} ${timingHeader} <style>${css}</style></head>${bodyTag}`
+
+          // Splice in the body
+          const [preRoot, postRoot] = htmlWithoutRoot.split('<div id="root"></div>')
+          const html = `${preRoot}<div id="root">${componentHTML}</div>${initialStateTag} ${initialGlamTag} ${initialIsoFetchesTag}${postRoot}`
           console.log(`[${requestId}][prerender] Rendering 200 (total ${new Date() - startTime}ms)`)
           resolve({ type: 'render', body: html, postIds, postTokens, streamKind, streamId })
         }


### PR DESCRIPTION
Thanks to a quirk of `String.replace`, a post including `$'` would render weirdly because the match would get duplicated back into the body a second time. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter for an explanation of the mechanics.

Eventually, would be nice for the pipeline to return `&apos;` instead of `'` which would get around this with fewer machinations, but this does the job for now.

[Finishes #144326413](https://www.pivotaltracker.com/story/show/144326413)