### PR TITLE
Bust the iso cache when the build hash changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 dist/
 .tern-port
 public/static/emojis.json
+stats.json

--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -70,6 +70,7 @@ librato.on('error', (err) => {
 app.use(helmet())
 
 const indexStr = fs.readFileSync(path.join(__dirname, '../public/index.html'), 'utf-8')
+const stats = JSON.parse(fs.readFileSync(path.join(__dirname, '../stats.json'), 'utf-8'))
 
 // Wire up OAuth route
 addOauthRoute(app)
@@ -221,8 +222,8 @@ app.use((req, res) => {
   const timingHeader = newrelic.getBrowserTimingHeader()
 
   if (canPrerenderRequest(req)) {
-    const cacheGeneration = '1'
-    const cacheKey = cacheKeyForRequest(req, cacheGeneration)
+    // Ensure the cache gets busted when new JS is deployed
+    const cacheKey = cacheKeyForRequest(req, stats.hash)
     console.log(`[${requestId}][handler] Attempting to serve pre-rendered markup for path`, req.url, cacheKey)
     memcacheClient.get(cacheKey, (err, value) => {
       if (value) {

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -35,7 +35,14 @@ module.exports = {
       ENV: JSON.stringify(require(path.join(__dirname, './env.js')))
     }),
     new webpack.BannerPlugin('require("source-map-support").install();',
-                             {raw: true, entryOnly: false})
+                             {raw: true, entryOnly: false}),
+    function() {
+      this.plugin("done", (stats) => {
+        fs.writeFileSync(
+          path.join(__dirname, "stats.json"),
+          JSON.stringify(stats.toJson()))
+      })
+    }
   ],
   module:  {
     loaders: [


### PR DESCRIPTION
This incorporates the build hash from Webpack into the cache key for Memcache for iso responses, which will result in the cache getting blown every time we do a deploy.

While there's a minor performance hit associated with this, it should help our sanity on deploy as it will ensure that whatever markup users are getting is reflecting the latest deployed code.

See https://webpack.github.io/docs/long-term-caching.html for details on the stats JSON that Webpack emits.

[Finishes #144559667](https://www.pivotaltracker.com/story/show/144559667)