### PR TITLE
Generates a stats.json file for the build:web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .tern-port
 public/static/emojis.json
 stats.json
+web-stats.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "clean": "rm -f public/index.html public/static/*.js public/static/*.map public/static/*.css",
     "build": "yarn run build:web && yarn run build:server",
     "build:server": "NODE_ENV=production node ./node_modules/webpack/bin/webpack.js --config=webpack.server.config.js",
-    "build:web": "NODE_ENV=production node ./node_modules/webpack/bin/webpack.js -p --config=webpack.prod.config.js",
+    "build:web": "NODE_ENV=production node ./node_modules/webpack/bin/webpack.js -p --config=webpack.prod.config.js --json > web-stats.json",
     "dev": "yarn run clean && DEBUG=express:* NODE_ENV=development babel-node server-dev.js",
     "flow": "flow",
     "lint": "yarn run lint:js && yarn run lint:css",


### PR DESCRIPTION
Handy if you drop this file onto [webpack visualizer](https://chrisbateman.github.io/webpack-visualizer/) to get a breakdown on the modules within the compiled bundle. Works for the stats.json file generated from `build:server` as well.

![screen shot 2017-04-29 at 5 46 00 pm](https://cloud.githubusercontent.com/assets/78967/25559944/193a0fce-2d04-11e7-9eca-3401475c4f35.png)

[#138191507](https://www.pivotaltracker.com/story/show/138191507)