### PR TITLE
Proposal: Proxy http requests via node in dev.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ APP_DEBUG=false
 AUTH_CLIENT_ID=client-id-here
 AUTH_CLIENT_SECRET=client-secret-here
 AUTH_DOMAIN=http://staging.server.com
+API_DOMAIN=http://localhost:6660
 HONEYBADGER_API_KEY=honeybadger-api-key-here
 HONEYBADGER_ENVIRONMENT=honeybadger-environment
 LOGO_MARK=normal

--- a/env.js
+++ b/env.js
@@ -3,6 +3,7 @@ module.exports = {
   AUTH_CLIENT_ID: process.env.AUTH_CLIENT_ID,
   AUTH_CLIENT_SECRET: process.env.AUTH_CLIENT_SECRET,
   AUTH_DOMAIN: process.env.AUTH_DOMAIN,
+  API_DOMAIN: process.env.API_DOMAIN || process.env.AUTH_DOMAIN,
   HAS_GUIDE: (process.env.HAS_GUIDE === 'true'),
   LOGO_MARK: process.env.LOGO_MARK,
   NODE_ENV: process.env.NODE_ENV,

--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.10.3",
     "flow-bin": "0.45.0",
-    "http-proxy": "^1.16.2",
+    "http-proxy": "1.16.2",
     "mocha": "3.3.0",
     "react-addons-perf": "15.4.2",
     "react-addons-test-utils": "15.5.1",

--- a/package.json
+++ b/package.json
@@ -248,6 +248,7 @@
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.10.3",
     "flow-bin": "0.45.0",
+    "http-proxy": "^1.16.2",
     "mocha": "3.3.0",
     "react-addons-perf": "15.4.2",
     "react-addons-test-utils": "15.5.1",

--- a/server-dev.js
+++ b/server-dev.js
@@ -32,9 +32,9 @@ app.use(express.static('public'))
 app.use('/static', express.static('public/static'))
 
 // API Proxy
-app.use('/api/v2', (req, res, next) => {
+app.use('/api/', (req, res, next) => {
   // include root path in proxied request
-  req.url = '/api/v2/' + req.url
+  req.url = '/api/' + req.url
   proxy.web(req, res, {})
 })
 

--- a/src/networking/api.js
+++ b/src/networking/api.js
@@ -2,7 +2,7 @@ import { getPagingQueryParams } from '../helpers/uri_helper'
 
 const API_VERSION = 'v2'
 const PER_PAGE = 25
-const basePath = () => `${ENV.AUTH_DOMAIN}/api`
+const basePath = () => `${ENV.API_DOMAIN}/api`
 
 function getAPIPath(relPath, queryParams = {}) {
   let path = `${basePath()}/${API_VERSION}/${relPath}`

--- a/test/server/prerender_test.js
+++ b/test/server/prerender_test.js
@@ -17,6 +17,7 @@ describe('isomorphically rendering on the server', () => {
   after(() => { Helmet.canUseDOM = true })
 
   beforeEach(() => {
+    global.ENV.API_DOMAIN = 'https://ello.co'
     global.ENV.AUTH_DOMAIN = 'https://ello.co'
     global.ENV.AUTH_CLIENT_ID = 'abc123'
     global.ENV.AUTH_CLIENT_SECRET = 'def456'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,6 +2453,10 @@ eventemitter2@~0.4.14:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
 
+eventemitter3@1.x.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
+
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -3119,6 +3123,13 @@ http-errors@~1.6.1:
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
+
+http-proxy@^1.16.2:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742"
+  dependencies:
+    eventemitter3 "1.x.x"
+    requires-port "1.x.x"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -5573,7 +5584,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.55.0, request@~2.79.0:
+request@^2.55.0, request@^2.79.0, request@~2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -5598,7 +5609,7 @@ request@^2.55.0, request@~2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5643,6 +5654,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requires-port@1.x.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
 reselect@3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,7 +3124,7 @@ http-errors@~1.6.1:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
-http-proxy@^1.16.2:
+http-proxy@1.16.2:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742"
   dependencies:


### PR DESCRIPTION
@mkitt @rynbyjn I started digging into https://www.pivotaltracker.com/story/show/144530371, however with our sophisticated (read: complicated & clever) gateway code handling CORs there also was going to be difficult and verbose.

This is a proposal to handle the CORS issue an alternative way: don't use CORS in dev. The browser can hit the dev server (localhost:6660) and have requests proxied by node to the appropriate API. This would allow us to remove all CORS code across Mothership and Apex.

What do you think?