### PR TITLE
Add tracking to editorials

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -114,7 +114,7 @@ export function loadRelatedPosts(postId, perPage) {
   }
 }
 
-export function lovePost(post) {
+export function lovePost({ post, trackLabel, trackOptions }) {
   const postId = post.get('id')
   return {
     type: POST.LOVE,
@@ -122,6 +122,8 @@ export function lovePost(post) {
       endpoint: api.lovePost(postId),
       method: 'POST',
       model: post,
+      trackLabel,
+      trackOptions,
     },
     meta: {
       mappingType: MAPPING_TYPES.LOVES,
@@ -178,7 +180,8 @@ export function toggleReposting(post, isReposting) {
   }
 }
 
-export function unlovePost(post) {
+// Currently not tracking unlove's but trying to keep the api similar to the `lovePost` action.
+export function unlovePost({ post, trackLabel, trackOptions }) {
   const postId = post.get('id')
   return {
     type: POST.LOVE,
@@ -186,6 +189,8 @@ export function unlovePost(post) {
       endpoint: api.unlovePost(postId),
       method: 'DELETE',
       model: post,
+      trackLabel,
+      trackOptions,
     },
     meta: {
       resultKey: `/posts/${postId}/love`,

--- a/src/components/assets/BackgroundImage.js
+++ b/src/components/assets/BackgroundImage.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
@@ -61,11 +62,13 @@ const baseStyle = css(
 export default class BackgroundImage extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
+    onClick: PropTypes.func,
     to: PropTypes.string,
   }
 
   static defaultProps = {
     className: null,
+    onClick: null,
     to: null,
   }
 
@@ -94,7 +97,7 @@ export default class BackgroundImage extends PureComponent {
   }
 
   render() {
-    const { className, to } = this.props
+    const { className, onClick, to } = this.props
     const { status } = this.state
     const classList = classNames(`BackgroundImage ${baseStyle}`, status, className)
     const imageAssetProps = {
@@ -104,10 +107,10 @@ export default class BackgroundImage extends PureComponent {
       src: getSource(this.props),
     }
     return to ?
-      <Link className={classNames(classList, 'isLink')} to={to}>
+      <Link className={classNames(classList, 'isLink')} onClick={onClick} to={to}>
         <ImageAsset {...imageAssetProps} />
       </Link> :
-      <div className={classList}>
+      <div className={classList} onClick={onClick}>
         <ImageAsset {...imageAssetProps} />
       </div>
   }

--- a/src/components/editorials/EditorialLayout.js
+++ b/src/components/editorials/EditorialLayout.js
@@ -91,12 +91,12 @@ export default({ ids }: { ids: List<string> }) => (
     <Row>
       { ids.get(0) &&
         <Cell className={`${width2} ${height1} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(0)} size="2x1" />
+          <EditorialContainer editorialId={ids.get(0)} size="2x1" position={1} />
         </Cell>
       }
       { ids.get(1) &&
         <Cell className={`${width1} ${height1}`}>
-          <EditorialContainer editorialId={ids.get(1)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(1)} size="1x1" position={2} />
         </Cell>
       }
     </Row>
@@ -105,17 +105,17 @@ export default({ ids }: { ids: List<string> }) => (
     <Row>
       { ids.get(2) &&
         <Cell className={`${width1} ${height1} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(2)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(2)} size="1x1" position={3} />
         </Cell>
       }
       { ids.get(3) &&
         <Cell className={`${width1} ${height1} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(3)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(3)} size="1x1" position={4} />
         </Cell>
       }
       { ids.get(4) &&
         <Cell className={`${width1} ${height1}`}>
-          <EditorialContainer editorialId={ids.get(4)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(4)} size="1x1" position={5} />
         </Cell>
       }
     </Row>
@@ -124,17 +124,17 @@ export default({ ids }: { ids: List<string> }) => (
     <Row>
       { ids.get(5) &&
         <Cell className={`${width2} ${height2} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(5)} size="2x2" />
+          <EditorialContainer editorialId={ids.get(5)} size="2x2" position={6} />
         </Cell>
       }
       { ids.get(6) &&
         <Cell className={`${width1} ${height2}`}>
           <Cell className={halfHeight}>
-            <EditorialContainer editorialId={ids.get(6)} size="1x2" />
+            <EditorialContainer editorialId={ids.get(6)} size="1x2" position={7} />
           </Cell>
           { ids.get(7) &&
             <Cell className={`${halfHeight} ${alignEnd}`}>
-              <EditorialContainer editorialId={ids.get(7)} size="1x1" />
+              <EditorialContainer editorialId={ids.get(7)} size="1x1" position={8} />
             </Cell>
           }
         </Cell>
@@ -145,22 +145,22 @@ export default({ ids }: { ids: List<string> }) => (
     <Row>
       { ids.get(8) &&
         <Cell className={`${width1} ${height2} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(8)} size="1x2" />
+          <EditorialContainer editorialId={ids.get(8)} size="1x2" position={9} />
         </Cell>
       }
       { ids.get(9) &&
         <Cell className={`${width2} ${height2}`}>
           <Cell className={halfHeight}>
-            <EditorialContainer editorialId={ids.get(9)} size="2x1" />
+            <EditorialContainer editorialId={ids.get(9)} size="2x1" position={10} />
           </Cell>
           { ids.get(10) &&
             <Cell className={`${halfWidth} ${halfHeight} ${pushRight} ${alignEnd}`}>
-              <EditorialContainer editorialId={ids.get(10)} size="1x1" />
+              <EditorialContainer editorialId={ids.get(10)} size="1x1" position={11} />
             </Cell>
           }
           { ids.get(11) &&
             <Cell className={`${halfWidth} ${halfHeight} ${alignEnd}`}>
-              <EditorialContainer editorialId={ids.get(11)} size="1x1" />
+              <EditorialContainer editorialId={ids.get(11)} size="1x1" position={12} />
             </Cell>
           }
         </Cell>
@@ -173,12 +173,12 @@ export default({ ids }: { ids: List<string> }) => (
     <Row>
       { ids.get(12) &&
         <Cell className={`${width1} ${height1} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(12)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(12)} size="1x1" position={13} />
         </Cell>
       }
       { ids.get(13) &&
         <Cell className={`${width2} ${height1}`}>
-          <EditorialContainer editorialId={ids.get(13)} size="2x1" />
+          <EditorialContainer editorialId={ids.get(13)} size="2x1" position={14} />
         </Cell>
       }
     </Row>
@@ -187,17 +187,17 @@ export default({ ids }: { ids: List<string> }) => (
     <Row>
       { ids.get(14) &&
         <Cell className={`${width1} ${height1} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(14)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(14)} size="1x1" position={15} />
         </Cell>
       }
       { ids.get(15) &&
         <Cell className={`${width1} ${height1} ${pushRight}`}>
-          <EditorialContainer editorialId={ids.get(15)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(15)} size="1x1" position={16} />
         </Cell>
       }
       { ids.get(16) &&
         <Cell className={`${width1} ${height1}`}>
-          <EditorialContainer editorialId={ids.get(16)} size="1x1" />
+          <EditorialContainer editorialId={ids.get(16)} size="1x1" position={17} />
         </Cell>
       }
     </Row>
@@ -207,18 +207,18 @@ export default({ ids }: { ids: List<string> }) => (
       { ids.get(17) &&
         <Cell className={`${width1} ${height2} ${pushRight}`}>
           <Cell className={halfHeight}>
-            <EditorialContainer editorialId={ids.get(17)} size="1x1" />
+            <EditorialContainer editorialId={ids.get(17)} size="1x1" position={18} />
           </Cell>
           { ids.get(18) &&
             <Cell className={`${halfHeight} ${alignEnd}`}>
-              <EditorialContainer editorialId={ids.get(18)} size="1x1" />
+              <EditorialContainer editorialId={ids.get(18)} size="1x1" position={19} />
             </Cell>
           }
         </Cell>
       }
       { ids.get(19) &&
         <Cell className={`${width2} ${height2}`}>
-          <EditorialContainer editorialId={ids.get(19)} size="2x2" />
+          <EditorialContainer editorialId={ids.get(19)} size="2x2" position={20} />
         </Cell>
       }
     </Row>
@@ -228,23 +228,23 @@ export default({ ids }: { ids: List<string> }) => (
       { ids.get(20) &&
         <Cell className={`${width2} ${height2} ${pushRight}`}>
           <Cell className={halfHeight}>
-            <EditorialContainer editorialId={ids.get(20)} size="2x1" />
+            <EditorialContainer editorialId={ids.get(20)} size="2x1" position={21} />
           </Cell>
           { ids.get(21) &&
             <Cell className={`${halfWidth} ${halfHeight} ${pushRight} ${alignEnd}`}>
-              <EditorialContainer editorialId={ids.get(21)} size="1x1" />
+              <EditorialContainer editorialId={ids.get(21)} size="1x1" position={22} />
             </Cell>
           }
           { ids.get(22) &&
             <Cell className={`${halfWidth} ${halfHeight} ${alignEnd}`}>
-              <EditorialContainer editorialId={ids.get(22)} size="1x1" />
+              <EditorialContainer editorialId={ids.get(22)} size="1x1" position={23} />
             </Cell>
           }
         </Cell>
       }
       { ids.get(23) &&
         <Cell className={`${width1} ${height2}`}>
-          <EditorialContainer editorialId={ids.get(23)} size="1x2" />
+          <EditorialContainer editorialId={ids.get(23)} size="1x2" position={24} />
         </Cell>
       }
     </Row>

--- a/src/components/editorials/EditorialRenderables.js
+++ b/src/components/editorials/EditorialRenderables.js
@@ -37,15 +37,14 @@ export const PostEditorial = (props: EditorialProps) => (
     </header>
     <div className={bodyStyle}>
       <EditorialSubtitle label={props.editorial.get('subtitle')} />
-      <EditorialTools
-        isPostLoved={props.isPostLoved}
-        postPath={props.postPath}
-      />
+      <EditorialTools isPostLoved={props.isPostLoved} postPath={props.postPath} />
     </div>
     <BackgroundImage
       className="inEditorial hasOverlay5"
       dpi={props.dpi}
       sources={props.sources}
+      to={props.postPath}
+      onClick={props.onClickEditorial}
     />
   </div>
 )
@@ -62,6 +61,8 @@ export const CuratedPostEditorial = (props: EditorialProps) => (
       className="inEditorial hasOverlay5"
       dpi={props.dpi}
       sources={props.sources}
+      to={props.postPath}
+      onClick={props.onClickEditorial}
     />
   </div>
 )
@@ -78,6 +79,8 @@ export const ExternalEditorial = (props: EditorialProps) => (
       className="inEditorial hasOverlay5"
       dpi={props.dpi}
       sources={props.sources}
+      to={props.url}
+      onClick={props.onClickEditorial}
     />
   </div>
 )

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import classNames from 'classnames'
 import { selectIsLoggedIn } from '../selectors/authentication'
@@ -10,6 +11,7 @@ import { getCategories, getPagePromotionals } from '../actions/discover'
 import { setSignupModalLaunched } from '../actions/gui'
 import { openModal } from '../actions/modals'
 import { loadAnnouncements, loadNotifications } from '../actions/notifications'
+import { lovePost, unlovePost } from '../actions/posts'
 import { loadProfile } from '../actions/profile'
 import { fetchAuthenticationPromos } from '../actions/promotions'
 import RegistrationRequestDialog from '../components/dialogs/RegistrationRequestDialog'
@@ -34,6 +36,7 @@ import {
 import { selectIsAuthenticationView } from '../selectors/routing'
 import { scrollToPosition } from '../lib/jello'
 import * as ElloAndroidInterface from '../lib/android_interface'
+import ShareDialog from '../components/dialogs/ShareDialog'
 
 function mapStateToProps(state) {
   return {
@@ -87,6 +90,8 @@ class AppContainer extends Component {
     onClickTrackCredits: PropTypes.func,
     onClickTrackCTA: PropTypes.func,
     onLaunchNativeEditor: PropTypes.func,
+    openShareDialog: PropTypes.func,
+    toggleLovePost: PropTypes.func,
   }
 
   getChildContext() {
@@ -96,6 +101,8 @@ class AppContainer extends Component {
       onClickTrackCredits: this.onClickTrackCredits,
       onClickTrackCTA: this.onClickTrackCTA,
       onLaunchNativeEditor: this.onLaunchNativeEditor,
+      openShareDialog: this.openShareDialog,
+      toggleLovePost: this.toggleLovePost,
     }
   }
 
@@ -142,6 +149,8 @@ class AppContainer extends Component {
     removeGlobalDrag()
   }
 
+  // TODO: Rename this to openRegistrationRequestDialog since it's a method
+  // call and not coming directly from an event.
   onClickOpenRegistrationRequestDialog = (trackPostfix = 'modal') => {
     const { authPromo, dispatch, isAuthenticationView } = this.props
     if (isAuthenticationView || !authPromo) { return }
@@ -182,6 +191,27 @@ class AppContainer extends Component {
       `${isComment}`,
       comment ? JSON.stringify(comment.toJS()) : null,
     )
+  }
+
+  openShareDialog = ({ post, postAuthor, trackLabel, trackOptions }) => {
+    const { dispatch } = this.props
+    const action = bindActionCreators(trackEvent, dispatch)
+    dispatch(openModal(
+      <ShareDialog author={postAuthor} post={post} trackEvent={action} />,
+      '',
+      null,
+      trackLabel || 'open-share-dialog',
+      trackOptions || {},
+    ))
+  }
+
+  toggleLovePost = ({ isLoved, post, trackLabel, trackOptions }) => {
+    const { dispatch } = this.props
+    if (isLoved) {
+      dispatch(unlovePost({ post, trackLabel, trackOptions }))
+    } else {
+      dispatch(lovePost({ post, trackLabel, trackOptions }))
+    }
   }
 
   render() {

--- a/src/containers/PostContainer.js
+++ b/src/containers/PostContainer.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { push, replace } from 'react-router-redux'
-import { bindActionCreators } from 'redux'
 import classNames from 'classnames'
 import set from 'lodash/set'
 import { selectIsLoggedIn } from '../selectors/authentication'
@@ -55,18 +54,15 @@ import {
   flagPost,
   loadComments,
   loadEditablePost,
-  lovePost,
   toggleComments,
   toggleEditing,
   toggleReposting,
-  unlovePost,
   unwatchPost,
   watchPost,
 } from '../actions/posts'
 import StreamContainer from '../containers/StreamContainer'
 import ConfirmDialog from '../components/dialogs/ConfirmDialog'
 import FlagDialog from '../components/dialogs/FlagDialog'
-import ShareDialog from '../components/dialogs/ShareDialog'
 import Editor from '../components/editor/Editor'
 import {
   CategoryHeader,
@@ -213,6 +209,8 @@ class PostContainer extends Component {
   static contextTypes = {
     onClickOpenRegistrationRequestDialog: PropTypes.func.isRequired,
     onLaunchNativeEditor: PropTypes.func.isRequired,
+    openShareDialog: PropTypes.func.isRequired,
+    toggleLovePost: PropTypes.func.isRequired,
   }
 
   getChildContext() {
@@ -287,12 +285,10 @@ class PostContainer extends Component {
   }
 
   onClickLovePost = () => {
-    const { dispatch, post, postLoved } = this.props
-    if (postLoved) {
-      dispatch(unlovePost(post))
-    } else {
-      dispatch(lovePost(post))
-    }
+    const { postLoved, post } = this.props
+    const { toggleLovePost } = this.context
+    const trackLabel = 'web_production.post_actions_love'
+    toggleLovePost({ isLoved: postLoved, post, trackLabel })
   }
 
   onClickRepostPost = () => {
@@ -307,9 +303,9 @@ class PostContainer extends Component {
   }
 
   onClickSharePost = () => {
-    const { author, dispatch, post } = this.props
-    const action = bindActionCreators(trackEvent, dispatch)
-    dispatch(openModal(<ShareDialog author={author} post={post} trackEvent={action} />, '', null, 'open-share-dialog'))
+    const { post, author } = this.props
+    const { openShareDialog } = this.context
+    openShareDialog({ post, author })
   }
 
   onClickToggleComments = () => {

--- a/src/sagas/analytics.js
+++ b/src/sagas/analytics.js
@@ -60,7 +60,7 @@ function* trackEvents() {
       case ACTION_TYPES.POST.LOVE_REQUEST: {
         const method = get(action, 'payload.method')
         if (method === 'POST') {
-          yield put(trackEventAction('web_production.post_actions_love'))
+          yield put(trackEventAction(get(action, 'payload.trackLabel'), get(action, 'payload.trackOptions')))
         }
         break
       }

--- a/src/selectors/editorial.js
+++ b/src/selectors/editorial.js
@@ -8,6 +8,9 @@ import type { EditorialProps } from '../types/flowtypes'
 const selectPropsSize = (state, props) =>
   get(props, 'size', '1x1')
 
+const selectPropsPosition = (state, props) =>
+  get(props, 'position')
+
 export const selectPropsEditorialId = (state: any, props: EditorialProps) =>
   get(props, 'editorialId') || get(props, 'editorial', Map()).get('id')
 
@@ -22,11 +25,6 @@ export const selectEditorial = createSelector(
     editorials.get(editorialId, Map()),
 )
 
-export const selectEditorialPostId = createSelector(
-  [selectEditorial], editorial =>
-    editorial.getIn(['links', 'post', 'id']),
-)
-
 export const selectEditorialImageSource = createSelector(
   [selectEditorial, selectPropsSize], (editorial, size) => {
     switch (size) {
@@ -38,4 +36,32 @@ export const selectEditorialImageSource = createSelector(
     }
   },
 )
+
+export const selectEditorialKind = createSelector(
+  [selectEditorial], editorial =>
+    editorial.get('kind'),
+)
+
+export const selectEditorialPostId = createSelector(
+  [selectEditorial], editorial =>
+    editorial.getIn(['links', 'post', 'id']),
+)
+
+export const selectEditorialUrl = createSelector(
+  [selectEditorial], editorial =>
+    editorial.get('url'),
+)
+
+// Derived
+export const selectEditorialAnalyticsOptions = createSelector(
+  [selectEditorialKind, selectEditorialPostId, selectPropsPosition, selectPropsSize],
+  (kind, postId, position, size) => (
+    {
+      kind,
+      ...(postId ? { postId } : {}),
+      parent: 'editorial',
+      position,
+      size,
+    }
+))
 

--- a/test/unit/actions/posts_test.js
+++ b/test/unit/actions/posts_test.js
@@ -139,7 +139,7 @@ describe('posts.js', () => {
 
   context('#lovePost', () => {
     const post = stub('post')
-    const action = subject.lovePost(post)
+    const action = subject.lovePost({ post, trackLabel: 'track-love-post', trackOptions: { f: 1 } })
 
     it('is an FSA compliant action', () => {
       expect(isFSA(action)).to.be.true
@@ -153,6 +153,8 @@ describe('posts.js', () => {
       expect(action.payload.endpoint.path).to.contain('/posts/1/love')
       expect(action.payload.method).to.equal('POST')
       expect(action.payload.model).to.deep.equal(post)
+      expect(action.payload.trackLabel).to.deep.equal('track-love-post')
+      expect(action.payload.trackOptions).to.deep.equal({ f: 1 })
     })
 
     it('sets the appropriate meta information', () => {
@@ -218,7 +220,7 @@ describe('posts.js', () => {
 
   context('#unlovePost', () => {
     const post = stub('post')
-    const action = subject.unlovePost(post)
+    const action = subject.unlovePost({ post, trackLabel: 'track-unlove-post', trackOptions: { f: 2 } })
 
     it('is an FSA compliant action', () => {
       expect(isFSA(action)).to.be.true
@@ -233,6 +235,8 @@ describe('posts.js', () => {
       expect(action.payload.endpoint.path).to.contain('/posts/1/love')
       expect(action.payload.method).to.equal('DELETE')
       expect(action.payload.model).to.deep.equal(post)
+      expect(action.payload.trackLabel).to.deep.equal('track-unlove-post')
+      expect(action.payload.trackOptions).to.deep.equal({ f: 2 })
     })
 
     it('sets the appropriate meta information', () => {

--- a/test/unit/selectors/editorial_test.js
+++ b/test/unit/selectors/editorial_test.js
@@ -71,13 +71,6 @@ describe('editorial selectors', () => {
     })
   })
 
-  context('#selectEditorialPostId', () => {
-    it('returns the correct linked post id', () => {
-      const props = { editorialId: 'editorialPostId' }
-      expect(selector.selectEditorialPostId(state, props)).to.equal('1')
-    })
-  })
-
   context('#selectEditorialImageSource', () => {
     it('returns the correct image source based on a size of 1x1', () => {
       const props = { editorialId: 'editorialPostId', size: '1x1' }
@@ -105,6 +98,71 @@ describe('editorial selectors', () => {
       const expected = editorialPost.get('twoByTwoImage')
       const result = selector.selectEditorialImageSource(state, props)
       expect(expected).to.equal(result)
+    })
+  })
+
+  context('#selectEditorialKind', () => {
+    it('returns the correct editorial kind', () => {
+      let expected = 'post'
+      let result = selector.selectEditorialKind(state, { editorialId: 'editorialPostId' })
+      expect(expected).to.equal(result)
+
+      expected = 'post_stream'
+      result = selector.selectEditorialKind(state, { editorialId: 'editorialCuratedId' })
+      expect(expected).to.equal(result)
+
+      expected = 'external'
+      result = selector.selectEditorialKind(state, { editorialId: 'editorialExternalId' })
+      expect(expected).to.equal(result)
+    })
+  })
+
+  context('#selectEditorialPostId', () => {
+    it('returns the correct linked post id', () => {
+      const props = { editorialId: 'editorialPostId' }
+      expect(selector.selectEditorialPostId(state, props)).to.equal('1')
+    })
+  })
+
+  context('#selectEditorialUrl', () => {
+    it('returns the url property on a ExternalEditorial', () => {
+      const expected = '/external/url'
+      const result = selector.selectEditorialUrl(state, { editorialId: 'editorialExternalId' })
+      expect(expected).to.equal(result)
+    })
+
+    it('returns undefined for url on a non ExternalEditorial', () => {
+      const expected = undefined
+      const result = selector.selectEditorialUrl(state, { editorialId: 'editorialCuratedId' })
+      expect(expected).to.equal(result)
+    })
+  })
+
+  context('#selectEditorialAnalyticsOptions', () => {
+    it('returns the correct editorial analytics options', () => {
+      let expected = { kind: 'post', postId: '1', parent: 'editorial', position: 2, size: '2x1' }
+      let result = selector.selectEditorialAnalyticsOptions(state, {
+        editorialId: 'editorialPostId',
+        position: 2,
+        size: '2x1',
+      })
+      expect(expected).to.deep.equal(result)
+
+      expected = { kind: 'post_stream', parent: 'editorial', position: 1, size: '2x2' }
+      result = selector.selectEditorialAnalyticsOptions(state, {
+        editorialId: 'editorialCuratedId',
+        position: 1,
+        size: '2x2',
+      })
+      expect(expected).to.deep.equal(result)
+
+      expected = { kind: 'external', parent: 'editorial', position: 12, size: '1x1' }
+      result = selector.selectEditorialAnalyticsOptions(state, {
+        editorialId: 'editorialExternalId',
+        position: 12,
+        size: '1x1',
+      })
+      expect(expected).to.deep.equal(result)
     })
   })
 })


### PR DESCRIPTION
Also promoted common behaviors (love/unlove, share) from post and editorials up to context methods within the `AppContainer`. Editorials themselves require a bit more payload in their tracking options like: position, size, kind, etc. This resulted in passing optional `trackLabel` and `trackOptions` through the actions. This should allow for some custom behavior without straying to far off course.

[Finishes: #144489543](https://www.pivotaltracker.com/story/show/144489543)