### PR TITLE
Allow tall images to pass through without resizing

### DIFF
--- a/src/helpers/file_helper.js
+++ b/src/helpers/file_helper.js
@@ -137,7 +137,7 @@ export function getBlobFromBase64(b64Data, contentType, sliceSize) {
   return new Blob(byteArrays, { type })
 }
 
-export function processImage({ exifData, file, fileType, maxWidth = 2560, maxHeight = 5000 }) {
+export function processImage({ exifData, file, fileType, maxWidth = 2560, maxHeight = 7680 }) {
   return new Promise((resolve, reject) => {
     const img = new Image()
     img.onload = () => {


### PR DESCRIPTION
Corollary to https://github.com/ello/ello/pull/2037, let the height be
up to 3x the width.