### PR TITLE
Dump webpack stats to a subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ coverage
 dist/
 .tern-port
 public/static/emojis.json
-stats.json
-web-stats.json
+webpack-stats/*.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "clean": "rm -f public/index.html public/static/*.js public/static/*.map public/static/*.css",
     "build": "yarn run build:web && yarn run build:server",
     "build:server": "NODE_ENV=production node ./node_modules/webpack/bin/webpack.js --config=webpack.server.config.js",
-    "build:web": "NODE_ENV=production node ./node_modules/webpack/bin/webpack.js -p --config=webpack.prod.config.js --json > web-stats.json",
+    "build:web": "NODE_ENV=production node ./node_modules/webpack/bin/webpack.js -p --config=webpack.prod.config.js",
     "dev": "yarn run clean && DEBUG=express:* NODE_ENV=development babel-node server-dev.js",
     "flow": "flow",
     "lint": "yarn run lint:js && yarn run lint:css",

--- a/src/server-iso.js
+++ b/src/server-iso.js
@@ -70,7 +70,7 @@ librato.on('error', (err) => {
 app.use(helmet())
 
 const indexStr = fs.readFileSync(path.join(__dirname, '../public/index.html'), 'utf-8')
-const stats = JSON.parse(fs.readFileSync(path.join(__dirname, '../stats.json'), 'utf-8'))
+const stats = JSON.parse(fs.readFileSync(path.join(__dirname, '../webpack-stats/server.json'), 'utf-8'))
 
 // Wire up OAuth route
 addOauthRoute(app)

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -13,6 +13,8 @@ const postcssPxToRem = require('postcss-pxtorem')
 const postcssReporter = require('postcss-reporter')
 const postcssUrl = require('postcss-url')
 const pkg = require('./package.json')
+const fs = require('fs')
+
 // load env vars first
 require('dotenv').load({ silent: process.env.NODE_ENV === 'production' })
 
@@ -52,6 +54,13 @@ module.exports = {
       },
     }),
     new webpack.optimize.OccurenceOrderPlugin(true),
+    function() {
+      this.plugin("done", (stats) => {
+        fs.writeFileSync(
+          path.join(__dirname, "webpack-stats/prod.json"),
+          JSON.stringify(stats.toJson()))
+      })
+    }
   ],
   module: {
     loaders: [

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -39,7 +39,7 @@ module.exports = {
     function() {
       this.plugin("done", (stats) => {
         fs.writeFileSync(
-          path.join(__dirname, "stats.json"),
+          path.join(__dirname, "webpack-stats/server.json"),
           JSON.stringify(stats.toJson()))
       })
     }


### PR DESCRIPTION
Make it easier to ignore but restore the output of stats for the web task.

[Finishes: #145204839](https://www.pivotaltracker.com/story/show/145204839)