### PR TITLE
Cache the `public` directory across builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,5 +209,6 @@
     "webpack-dev-middleware": "1.10.2",
     "webpack-hot-middleware": "2.17.1",
     "why-did-you-update": "0.0.8"
-  }
+  },
+  "cacheDirectories": ["node_modules", "public"]
 }


### PR DESCRIPTION
This should ensure that older versions of main.js can continue to be
served across restarts.

Doesn't do anything to remove old versions, we'll need to figure that
piece out at some point.

More detail in Heroku's Devcenter:

https://devcenter.heroku.com/articles/nodejs-support#custom-caching