### PR TITLE
Revert "Specify the hash in the filename for generated JS/CSS"

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -26,8 +26,8 @@ module.exports = {
     main: './src/main',
   },
   output: {
-    filename: '[name]-[hash].entry.js',
-    chunkFilename: '[id]-[chunkhash].chunk.js',
+    filename: '[name].entry.js',
+    chunkFilename: '[id].chunk.js',
     hash: true,
     path: path.join(__dirname, 'public/static'),
     publicPath: `${(process.env.CDN || '')}/static/`,


### PR DESCRIPTION
This reverts commit b9c7794e967445dcfb2fe47a151e17955a092271. Should prevent 404s on deploy.