### PR TITLE
Pluralize editorial stream kind

### DIFF
--- a/src/server/prerender.js
+++ b/src/server/prerender.js
@@ -60,7 +60,7 @@ function getPostTrackingMetadata(url, state, renderProps) {
 
   switch (selectViewNameFromRoute(state, renderProps)) {
     case 'editorial':
-      streamKind = 'editorial'
+      streamKind = 'editorials'
       break
     case 'search':
       streamKind = 'search'

--- a/test/server/prerender_test.js
+++ b/test/server/prerender_test.js
@@ -418,7 +418,7 @@ describe('isomorphically rendering on the server', () => {
             '48',
           ])
           expect(result.postTokens).to.eql([])
-          expect(result.streamKind).to.equal('editorial')
+          expect(result.streamKind).to.equal('editorials')
           expect(result.streamId).to.equal(null)
           const document = jsdom.jsdom(result.body)
           expect(document.querySelectorAll('main.Editorial')).to.have.lengthOf(1)


### PR DESCRIPTION
- This will make it consistent with how we named it in the API