### PR TITLE
Post Actions Buttons: Fix for Safari icon mis-alignment

### DIFF
--- a/src/components/assets/Icons.css
+++ b/src/components/assets/Icons.css
@@ -446,6 +446,10 @@
   stroke-width: 0.5;
 }
 
+.PostActionButton {
+  display: inline-block;
+}
+
 .PostActionButton > .BrowseIcon > g {
   fill: transparent;
 }


### PR DESCRIPTION
#295 may make this irrelevant?

Fixes this situation:

<img width="859" alt="jzjthu" src="https://user-images.githubusercontent.com/867428/30658642-3f8ad70a-9df0-11e7-9e9b-b4fd88bbbf94.png">