### PR TITLE
Fix the Post Actions by removing button text.

### DIFF
--- a/src/components/editor/PostActionBar.js
+++ b/src/components/editor/PostActionBar.js
@@ -95,12 +95,10 @@ const labelStyle = css(
     select('& + .SVGIcon', { marginRight: 11 }),
     parent(
       '.PostDetail .forComment',
-      s.inlineBlock,
-      select('& + .SVGIcon', { marginRight: 11 }),
+      select('& + .SVGIcon', { marginRight: 11, marginLeft: 11 }),
     ),
     parent(
       '.isComment .forComment',
-      s.inlineBlock,
       select('& + .SVGIcon', { marginRight: 11 }),
     ),
   ),


### PR DESCRIPTION
Hides "Comment" in the post detail sidebar.

https://www.pivotaltracker.com/story/show/151371732