### PR TITLE
Shows "Comment" button on mobile, and other refactors

### DIFF
--- a/src/components/editor/Editor.js
+++ b/src/components/editor/Editor.js
@@ -78,6 +78,7 @@ class Editor extends Component {
     isPostEditing: PropTypes.bool.isRequired,
     isPostEmpty: PropTypes.bool.isRequired,
     isPostReposting: PropTypes.bool.isRequired,
+    onCancel: PropTypes.func,
     onSubmit: PropTypes.func,
     post: PropTypes.object,
     shouldPersist: PropTypes.bool,
@@ -92,6 +93,7 @@ class Editor extends Component {
     isLoggedIn: false,
     isOwnPage: false,
     isOwnPost: false,
+    onCancel: null,
     onSubmit: null,
     post: null,
     shouldPersist: false,
@@ -207,7 +209,7 @@ class Editor extends Component {
   }
 
   cancelConfirmed = () => {
-    const { comment, dispatch, isPostEmpty, post } = this.props
+    const { comment, dispatch, isPostEmpty, onCancel, post } = this.props
     this.closeModal()
     dispatch(resetEditor(this.getEditorIdentifier()))
     dispatch(closeOmnibar())
@@ -218,6 +220,7 @@ class Editor extends Component {
     if (comment) {
       dispatch(toggleCommentEditing(comment, false))
     }
+    if (onCancel) { onCancel() }
   }
 
   render() {

--- a/src/components/posts/PostRenderables.js
+++ b/src/components/posts/PostRenderables.js
@@ -421,26 +421,56 @@ const launchCommentEditorButtonStyle = css(
   ),
 )
 
-export const LaunchCommentEditorButton = ({ avatar, post }, { onLaunchNativeEditor }) =>
+export const LaunchNativeCommentEditorButton = ({ avatar, post }, { onLaunchNativeEditor }) =>
+  <LaunchCommentEditorButton avatar={avatar} post={post} onLaunch={onLaunchNativeEditor} />
+
+export const LaunchMobileCommentEditorButton = ({ avatar, post }, { onToggleInlineCommenting }) =>
+  <LaunchCommentEditorButton avatar={avatar} post={post} onLaunch={onToggleInlineCommenting} />
+
+const LaunchCommentEditorButton = ({ avatar, post, onLaunch }) =>
   (<div className={launchCommentEditorStyle}>
     <Avatar className={`${launchCommentEditorAvatarStyle}`} sources={avatar} />
     <button
       className={launchCommentEditorButtonStyle}
-      onClick={() => onLaunchNativeEditor(post, true, null)}
+      onClick={() => onLaunch(post, true, null)}
     >
       Comment...
     </button>
   </div>)
+
+LaunchNativeCommentEditorButton.propTypes = {
+  avatar: PropTypes.object,
+  post: PropTypes.object,
+}
+LaunchNativeCommentEditorButton.defaultProps = {
+  avatar: null,
+  post: null,
+}
+LaunchNativeCommentEditorButton.contextTypes = {
+  onLaunchNativeEditor: PropTypes.func.isRequired,
+}
+
+LaunchMobileCommentEditorButton.propTypes = {
+  avatar: PropTypes.object,
+  post: PropTypes.object,
+}
+LaunchMobileCommentEditorButton.defaultProps = {
+  avatar: null,
+  post: null,
+}
+LaunchMobileCommentEditorButton.contextTypes = {
+  onToggleInlineCommenting: PropTypes.func.isRequired,
+}
+
 LaunchCommentEditorButton.propTypes = {
   avatar: PropTypes.object,
   post: PropTypes.object,
+  onLaunch: PropTypes.func,
 }
 LaunchCommentEditorButton.defaultProps = {
   avatar: null,
   post: null,
-}
-LaunchCommentEditorButton.contextTypes = {
-  onLaunchNativeEditor: PropTypes.func.isRequired,
+  onLaunch: null,
 }
 
 const relatedPostButtonStyle = css(
@@ -561,7 +591,7 @@ export const Post = ({
       }}
     />
     {isLoggedIn && showCommentEditor && supportsNativeEditor &&
-      <LaunchCommentEditorButton avatar={avatar} post={post} />
+      <LaunchNativeCommentEditorButton avatar={avatar} post={post} />
     }
     {showCommentEditor && !supportsNativeEditor && <Editor post={post} isComment />}
     {showCommentEditor &&

--- a/src/components/views/PostDetail.js
+++ b/src/components/views/PostDetail.js
@@ -158,9 +158,6 @@ PostDetail.propTypes = {
   post: PropTypes.object.isRequired,
   shouldInlineComments: PropTypes.bool.isRequired,
 }
-PostDetail.contextTypes = {
-  onLaunchNativeEditor: PropTypes.func.isRequired,
-}
 
 export const PostDetailError = ({ children }) =>
   (<MainView className="PostDetail">

--- a/src/components/views/PostDetail.js
+++ b/src/components/views/PostDetail.js
@@ -96,17 +96,20 @@ const asideStyle = css(
 const CommentContent = (
   { activeType, avatar, hasEditor, isInlineCommenting, isLoggedIn, post, streamAction },
   { onToggleInlineCommenting },
-  ) => (
+  ) => {
+  let editorOrButton = null
+  if (isLoggedIn && ElloAndroidInterface.supportsNativeEditor()) {
+    editorOrButton = <LaunchNativeCommentEditorButton avatar={avatar} post={post} />
+  } else if (hasEditor && activeType === 'comments') {
+    if (isInlineCommenting) {
+      editorOrButton = <Editor post={post} isComment onCancel={onToggleInlineCommenting} />
+    } else {
+      editorOrButton = <LaunchMobileCommentEditorButton avatar={avatar} post={post} />
+    }
+  }
+  return (
     <div className="CommentContent">
-      {!isInlineCommenting &&
-        <LaunchMobileCommentEditorButton avatar={avatar} post={post} />
-      }
-      {isInlineCommenting && hasEditor && activeType === 'comments' && !ElloAndroidInterface.supportsNativeEditor() &&
-        <Editor post={post} isComment onCancel={onToggleInlineCommenting} />
-      }
-      {isLoggedIn && ElloAndroidInterface.supportsNativeEditor() &&
-        <LaunchNativeCommentEditorButton avatar={avatar} post={post} />
-      }
+      {editorOrButton}
       {streamAction &&
         <StreamContainer
           action={streamAction}
@@ -118,6 +121,7 @@ const CommentContent = (
       }
     </div>
   )
+}
 CommentContent.propTypes = {
   activeType: PropTypes.string.isRequired,
   avatar: PropTypes.object,
@@ -155,7 +159,7 @@ export const PostDetail = (props) => {
         {!shouldInlineComments &&
           <aside className={asideStyle}>
             <PostContainer type="PostDetailAsideTop" postId={post.get('id')} />
-            <CommentContent {...props} />
+            <CommentContent {...props} isInlineCommenting />
             <PostContainer type="PostDetailAsideBottom" postId={post.get('id')} />
           </aside>
         }

--- a/src/components/views/PostDetail.js
+++ b/src/components/views/PostDetail.js
@@ -5,7 +5,7 @@ import PostContainer from '../../containers/PostContainer'
 import StreamContainer from '../../containers/StreamContainer'
 import { MainView } from '../views/MainView'
 import { loadRelatedPosts } from '../../actions/posts'
-import { LaunchCommentEditorButton } from '../posts/PostRenderables'
+import { LaunchNativeCommentEditorButton } from '../posts/PostRenderables'
 import { css, hover, media, modifier, select } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import * as ElloAndroidInterface from '../../lib/android_interface'
@@ -96,9 +96,11 @@ const asideStyle = css(
 const CommentContent = (
   { activeType, avatar, hasEditor, isLoggedIn, post, streamAction }) => (
     <div className="CommentContent">
-      {hasEditor && activeType === 'comments' && !ElloAndroidInterface.supportsNativeEditor() && <Editor post={post} isComment />}
+      {hasEditor && activeType === 'comments' && !ElloAndroidInterface.supportsNativeEditor() &&
+        <Editor post={post} isComment onCancel={onToggleInlineCommenting} />
+      }
       {isLoggedIn && ElloAndroidInterface.supportsNativeEditor() &&
-        <LaunchCommentEditorButton avatar={avatar} post={post} />
+        <LaunchNativeCommentEditorButton avatar={avatar} post={post} />
       }
       {streamAction &&
         <StreamContainer

--- a/src/components/views/PostDetail.js
+++ b/src/components/views/PostDetail.js
@@ -5,7 +5,7 @@ import PostContainer from '../../containers/PostContainer'
 import StreamContainer from '../../containers/StreamContainer'
 import { MainView } from '../views/MainView'
 import { loadRelatedPosts } from '../../actions/posts'
-import { LaunchNativeCommentEditorButton } from '../posts/PostRenderables'
+import { LaunchMobileCommentEditorButton, LaunchNativeCommentEditorButton } from '../posts/PostRenderables'
 import { css, hover, media, modifier, select } from '../../styles/jss'
 import * as s from '../../styles/jso'
 import * as ElloAndroidInterface from '../../lib/android_interface'
@@ -94,9 +94,14 @@ const asideStyle = css(
 )
 
 const CommentContent = (
-  { activeType, avatar, hasEditor, isLoggedIn, post, streamAction }) => (
+  { activeType, avatar, hasEditor, isInlineCommenting, isLoggedIn, post, streamAction },
+  { onToggleInlineCommenting },
+  ) => (
     <div className="CommentContent">
-      {hasEditor && activeType === 'comments' && !ElloAndroidInterface.supportsNativeEditor() &&
+      {!isInlineCommenting &&
+        <LaunchMobileCommentEditorButton avatar={avatar} post={post} />
+      }
+      {isInlineCommenting && hasEditor && activeType === 'comments' && !ElloAndroidInterface.supportsNativeEditor() &&
         <Editor post={post} isComment onCancel={onToggleInlineCommenting} />
       }
       {isLoggedIn && ElloAndroidInterface.supportsNativeEditor() &&
@@ -117,15 +122,18 @@ CommentContent.propTypes = {
   activeType: PropTypes.string.isRequired,
   avatar: PropTypes.object,
   hasEditor: PropTypes.bool.isRequired,
+  isInlineCommenting: PropTypes.bool,
   isLoggedIn: PropTypes.bool.isRequired,
   post: PropTypes.object.isRequired,
   streamAction: PropTypes.object,
 }
 CommentContent.defaultProps = {
   avatar: null,
+  isInlineCommenting: false,
   streamAction: null,
 }
 CommentContent.contextTypes = {
+  onToggleInlineCommenting: PropTypes.func.isRequired,
 }
 
 // TODO: Remove references to the PostDetailStreamContainer styles

--- a/src/components/views/PostDetail.js
+++ b/src/components/views/PostDetail.js
@@ -124,7 +124,6 @@ CommentContent.defaultProps = {
   streamAction: null,
 }
 CommentContent.contextTypes = {
-  onClickDetailTab: PropTypes.func.isRequired,
 }
 
 // TODO: Remove references to the PostDetailStreamContainer styles

--- a/src/containers/PostDetailContainer.js
+++ b/src/containers/PostDetailContainer.js
@@ -76,18 +76,20 @@ class PostDetailContainer extends Component {
   }
 
   static childContextTypes = {
+    onToggleInlineCommenting: PropTypes.func.isRequired,
     onClickScrollToRelatedPosts: PropTypes.func.isRequired,
   }
 
   getChildContext() {
     return {
+      onToggleInlineCommenting: this.onToggleInlineCommenting,
       onClickScrollToRelatedPosts: this.onClickScrollToRelatedPosts,
     }
   }
 
   componentWillMount() {
     const { dispatch, paramsToken, paramsUsername } = this.props
-    this.state = { activeType: 'comments', renderType: POST.DETAIL_REQUEST }
+    this.state = { activeType: 'comments', isInlineCommenting: false, renderType: POST.DETAIL_REQUEST }
     dispatch(loadPostDetail(`~${paramsToken}`, `~${paramsUsername}`))
   }
 
@@ -131,9 +133,11 @@ class PostDetailContainer extends Component {
       ['hasRelatedPostsButton', 'paramsToken', 'paramsUsername'].some(prop =>
         nextProps[prop] !== this.props[prop],
       ) ||
-      ['activeType', 'renderType'].some(prop => nextState[prop] !== this.state[prop])
+      ['activeType', 'isInlineCommenting', 'renderType'].some(prop => nextState[prop] !== this.state[prop])
   }
 
+  onToggleInlineCommenting = () => {
+    this.setState({ isInlineCommenting: !this.state.isInlineCommenting })
   }
 
   onClickScrollToRelatedPosts = () => {
@@ -172,7 +176,7 @@ class PostDetailContainer extends Component {
       post,
       tabs,
     } = this.props
-    const { activeType, renderType } = this.state
+    const { activeType, isInlineCommenting, renderType } = this.state
     // render loading/failure if we don't have an initial post
     if (isPostEmpty) {
       if (renderType === POST.DETAIL_REQUEST) {
@@ -197,6 +201,7 @@ class PostDetailContainer extends Component {
       columnCount,
       hasEditor: author && author.get('hasCommentingEnabled') && !(post.get('isReposting') || post.get('isEditing')),
       hasRelatedPostsButton,
+      isInlineCommenting,
       isLoggedIn,
       key: `postDetail_${paramsToken}`,
       post,

--- a/src/containers/PostDetailContainer.js
+++ b/src/containers/PostDetailContainer.js
@@ -45,6 +45,10 @@ function mapStateToProps(state, props) {
   }
 }
 
+function getShouldInlineComments(innerWidth) {
+  return innerWidth < 960
+}
+
 class PostDetailContainer extends Component {
 
   static propTypes = {
@@ -127,8 +131,10 @@ class PostDetailContainer extends Component {
     if (!nextProps.author || !nextProps.post) { return false }
     // only allow innerWidth to allow a render if we cross the break 3
     // threshold on either side since innerWidth is calculated on resize
-    if ((nextProps.innerWidth >= 960 && this.props.innerWidth < 960) ||
-        (nextProps.innerWidth < 960 && this.props.innerWidth >= 960)) { return true }
+    if (getShouldInlineComments(nextProps.innerWidth) !==
+      getShouldInlineComments(this.props.innerWidth)) {
+      return true
+    }
     return !Immutable.is(nextProps.post, this.props.post) ||
       ['hasRelatedPostsButton', 'paramsToken', 'paramsUsername'].some(prop =>
         nextProps[prop] !== this.props[prop],
@@ -168,7 +174,6 @@ class PostDetailContainer extends Component {
       author,
       avatar,
       columnCount,
-      innerWidth,
       hasRelatedPostsButton,
       isLoggedIn,
       isPostEmpty,
@@ -205,7 +210,7 @@ class PostDetailContainer extends Component {
       isLoggedIn,
       key: `postDetail_${paramsToken}`,
       post,
-      shouldInlineComments: innerWidth < 960,
+      shouldInlineComments: getShouldInlineComments(this.props.innerWidth),
       streamAction: this.getStreamAction(),
       tabs,
     }

--- a/src/containers/PostDetailContainer.js
+++ b/src/containers/PostDetailContainer.js
@@ -86,11 +86,7 @@ class PostDetailContainer extends Component {
   }
 
   componentWillMount() {
-    const { dispatch, paramsToken, paramsUsername, post, isPostEmpty } = this.props
-    if (!isPostEmpty) {
-      this.lovesWasOpen = post.get('showLovers')
-      this.repostsWasOpen = post.get('showReposters')
-    }
+    const { dispatch, paramsToken, paramsUsername } = this.props
     this.state = { activeType: 'comments', renderType: POST.DETAIL_REQUEST }
     dispatch(loadPostDetail(`~${paramsToken}`, `~${paramsUsername}`))
   }

--- a/src/containers/PostDetailContainer.js
+++ b/src/containers/PostDetailContainer.js
@@ -76,13 +76,11 @@ class PostDetailContainer extends Component {
   }
 
   static childContextTypes = {
-    onClickDetailTab: PropTypes.func.isRequired,
     onClickScrollToRelatedPosts: PropTypes.func.isRequired,
   }
 
   getChildContext() {
     return {
-      onClickDetailTab: this.onClickDetailTab,
       onClickScrollToRelatedPosts: this.onClickScrollToRelatedPosts,
     }
   }
@@ -140,10 +138,6 @@ class PostDetailContainer extends Component {
       ['activeType', 'renderType'].some(prop => nextState[prop] !== this.state[prop])
   }
 
-  onClickDetailTab = (vo) => {
-    if (vo.type) {
-      this.setState({ activeType: vo.type })
-    }
   }
 
   onClickScrollToRelatedPosts = () => {


### PR DESCRIPTION
- some "tab" code is not needed (we used to have Loves/Reposts tabs)
- the comment button toggles the editor - cancelling shows the comment button again

[Finishes #151340754](https://www.pivotaltracker.com/story/show/151340754)