### PR TITLE
Post Headers: Timestamp fix for CategoryHeader

### DIFF
--- a/src/components/posts/PostRenderables.js
+++ b/src/components/posts/PostRenderables.js
@@ -234,7 +234,9 @@ export class CategoryHeader extends PureComponent {
             <span className="CategoryHeaderCategoryName">{categoryName}</span>
           </Link>
         </div>
-        <PostHeaderTimeAgoLink to={detailPath} createdAt={postCreatedAt} />
+        <div className="PostHeaderTools">
+          <PostHeaderTimeAgoLink to={detailPath} createdAt={postCreatedAt} />
+        </div>
       </header>
     )
   }


### PR DESCRIPTION
Matches `CategoryHeader` to other post headers.

https://www.pivotaltracker.com/story/show/151617440