### PR TITLE
Fix countdown.

### DIFF
--- a/src/components/artist_invites/ArtistInviteRenderables.js
+++ b/src/components/artist_invites/ArtistInviteRenderables.js
@@ -216,7 +216,7 @@ class ArtistInviteCountDown extends PureComponent {
     const pad = n => `${n}`.padStart(2, '0')
     const r = moment.duration(secondsRemaining, 'seconds')
     if (r.days() > 1) {
-      return `${r.days()} Days Remaining`
+      return `${Math.floor(r.asDays())} Days Remaining`
     }
     return `${pad(r.hours())}:${pad(r.minutes())}:${pad(r.seconds())} Remaining`
   }


### PR DESCRIPTION
We want the entire duration as days, not just the days part of the
duration without months considered.