### PR TITLE
Remove ‘editorial-module-viewed’ segment event

### DIFF
--- a/src/containers/EditorialContainer.js
+++ b/src/containers/EditorialContainer.js
@@ -75,11 +75,6 @@ class EditorialContainer extends Component {
     }
   }
 
-  componentDidMount() {
-    const { dispatch, trackOptions } = this.props
-    dispatch(trackEvent('editorial-module-viewed', trackOptions))
-  }
-
   shouldComponentUpdate(nextProps) {
     return (
       nextProps.editorialId !== this.props.editorialId ||


### PR DESCRIPTION
- We can track this via viewed_logged_*_page event

https://www.pivotaltracker.com/story/show/152212402