### PR TITLE
Include asset in region during serialization.

### DIFF
--- a/src/reducers/json.js
+++ b/src/reducers/json.js
@@ -81,12 +81,27 @@ methods.removePageId = (state, pageName, id) => {
   return state
 }
 
-function normalizeModel(type, model) {
-  if (type !== MAPPING_TYPES.POSTS) { return model }
+function normalizePostContentRegion(model, field, state) {
+  return model.get(field, Immutable.List()).map((region, index) => {
+    const id = `${model.get('id')}-${index}`
+    const assetId = region.getIn(['links', 'assets'])
+    if (region.get('kind') === 'image' && assetId) {
+      const asset = state.getIn(['assets', assetId])
+      if (asset) {
+        return region.merge({ id, asset })
+      }
+    }
+    return region.merge({ id })
+  })
+}
 
-  const content = model.get('content', Immutable.List()).map((region, index) =>
-    region.set('id', `${model.get('id')}-${index}`))
-  return model.set('content', content)
+function normalizeModel(type, model, state) {
+  if (type !== MAPPING_TYPES.POSTS) { return model }
+  return model.merge({
+    content: normalizePostContentRegion(model, 'content', state),
+    summary: normalizePostContentRegion(model, 'summary', state),
+    repostContent: normalizePostContentRegion(model, 'repostContent', state),
+  })
 }
 
 methods.mergeModel = (state, type, params) => {
@@ -97,7 +112,7 @@ methods.mergeModel = (state, type, params) => {
   params.id = `${params.id}`
   return state.setIn(
     [type, params.id],
-    normalizeModel(type, state.getIn([type, params.id], Immutable.Map()).mergeDeep(params)),
+    normalizeModel(type, state.getIn([type, params.id], Immutable.Map()).mergeDeep(params), state),
   )
 }
 

--- a/src/selectors/comment.js
+++ b/src/selectors/comment.js
@@ -2,9 +2,8 @@ import Immutable from 'immutable'
 import { createSelector } from 'reselect'
 import get from 'lodash/get'
 import { COMMENTS } from '../constants/mapping_types'
-import { selectAssets } from '../selectors/assets'
 import { selectId as selectProfileId, selectIsStaff } from '../selectors/profile'
-import { addAssetToRegion, selectPosts } from '../selectors/post'
+import { selectPosts } from '../selectors/post'
 import { selectUsers } from './user'
 
 export const selectPropsCommentId = (state, props) =>
@@ -22,10 +21,7 @@ export const selectComment = createSelector(
 // Properties on the comments reducer
 export const selectCommentAuthorId = createSelector([selectComment], comment => comment.get('authorId'))
 export const selectCommentBody = createSelector([selectComment], comment => comment.get('body'))
-export const selectCommentContent = createSelector(
-  [selectComment, selectAssets], (comment, assets) =>
-    comment.get('content', Immutable.Map()).map(region => addAssetToRegion(region, assets)),
-)
+export const selectCommentContent = createSelector([selectComment], comment => (comment.get('content') || Immutable.Map()))
 export const selectCommentCreatedAt = createSelector([selectComment], comment => comment.get('createdAt'))
 export const selectCommentOriginalPostId = createSelector([selectComment], comment => comment.get('originalPostId'))
 export const selectCommentPostId = createSelector([selectComment], comment => comment.get('postId'))

--- a/src/selectors/post.js
+++ b/src/selectors/post.js
@@ -7,7 +7,6 @@ import { selectCategoryCollection } from './categories'
 import { LOAD_STREAM_REQUEST } from '../constants/action_types'
 import { COMMENTS, POSTS } from '../constants/mapping_types'
 import { selectIsPostDetail } from './routing'
-import { selectAssets } from './assets'
 import { numberToHuman } from '../lib/number_to_human'
 import { selectIsLoggedIn } from './authentication'
 import { selectIsGridMode, selectIsMobile } from './gui'
@@ -37,31 +36,11 @@ export const selectPost = createSelector(
   },
 )
 
-export const addAssetToRegion = (region, assets) => {
-  if (region.get('kind') === 'image') {
-    let assetId = region.getIn(['links', 'assets'], -1)
-    if (assetId < 0) {
-      const assetMatch = region.getIn(['content', 'url'], '').match(/asset\/attachment\/(\d+)\//)
-      if (assetMatch) {
-        assetId = `${assetMatch[1]}`
-      }
-    }
-    const asset = assets.get(assetId)
-    if (asset) {
-      return region.set('asset', asset)
-    }
-  }
-  return region
-}
-
 // Properties on the post reducer
 export const selectPostAuthorId = createSelector([selectPost], post => post.get('authorId'))
 export const selectPostBody = createSelector([selectPost], post => post.get('body'))
 export const selectPostCommentsCount = createSelector([selectPost], post => countProtector(post.get('commentsCount')))
-export const selectPostContent = createSelector(
-  [selectPost, selectAssets], (post, assets) =>
-    (post.get('content') || Immutable.Map()).map(region => addAssetToRegion(region, assets)),
-)
+export const selectPostContent = createSelector([selectPost], post => (post.get('content') || Immutable.Map()))
 export const selectPostContentWarning = createSelector([selectPost], post => post.get('contentWarning'))
 export const selectPostCreatedAt = createSelector([selectPost], post => post.get('createdAt'))
 export const selectPostHref = createSelector([selectPost], post => post.get('href'))
@@ -70,18 +49,12 @@ export const selectPostIsAdultContent = createSelector([selectPost], post => pos
 export const selectPostMetaAttributes = createSelector([selectPost], post => post.get('metaAttributes', Immutable.Map()))
 export const selectPostLoved = createSelector([selectPost], post => post.get('loved'))
 export const selectPostLovesCount = createSelector([selectPost], post => countProtector(post.get('lovesCount')))
-export const selectPostRepostContent = createSelector(
-  [selectPost, selectAssets], (post, assets) =>
-    (post.get('repostContent') || Immutable.Map()).map(region => addAssetToRegion(region, assets)),
-)
+export const selectPostRepostContent = createSelector([selectPost], post => (post.get('repostContent') || Immutable.Map()))
 export const selectPostRepostId = createSelector([selectPost], post => post.get('repostId'))
 export const selectPostReposted = createSelector([selectPost], post => post.get('reposted'))
 export const selectPostRepostsCount = createSelector([selectPost], post => countProtector(post.get('repostsCount')))
 export const selectPostShowComments = createSelector([selectPost], post => post.get('showComments', false))
-export const selectPostSummary = createSelector(
-  [selectPost, selectAssets], (post, assets) =>
-    (post.get('summary') || Immutable.Map()).map(region => addAssetToRegion(region, assets)),
-)
+export const selectPostSummary = createSelector([selectPost], post => (post.get('summary') || Immutable.Map()))
 export const selectPostToken = createSelector([selectPost], post => post.get('token'))
 export const selectPostViewsCount = createSelector([selectPost], post => countProtector(post.get('viewsCount')))
 export const selectPostViewsCountRounded = createSelector(

--- a/test/unit/selectors/post_test.js
+++ b/test/unit/selectors/post_test.js
@@ -149,45 +149,6 @@ describe('post selectors', () => {
     })
   })
 
-  context('#addAssetToRegion', () => {
-    it('returns the region if the kind is not text', () => {
-      const region = Immutable.fromJS({
-        kind: 'text',
-      })
-      expect(selector.addAssetToRegion(region, {})).to.equal(region)
-    })
-
-    it('sets an asset on the region from links', () => {
-      const region = Immutable.fromJS({
-        kind: 'image',
-        links: { assets: '1' },
-      })
-      const assets = Immutable.fromJS({ 1: 'blah' })
-      const newRegion = selector.addAssetToRegion(region, assets)
-      expect(newRegion.get('asset')).to.equal('blah')
-    })
-
-    it('sets an asset on the region from the content url for notifications', () => {
-      const region = Immutable.fromJS({
-        kind: 'image',
-        content: { url: '/asset/attachment/1/' },
-      })
-      const assets = Immutable.fromJS({ 1: 'blah' })
-      const newRegion = selector.addAssetToRegion(region, assets)
-      expect(newRegion.get('asset')).to.equal('blah')
-    })
-
-    it('doesn\'t set an asset on the region if no asset exists', () => {
-      const region = Immutable.fromJS({
-        kind: 'image',
-        links: { assets: '2' },
-      })
-      const assets = Immutable.fromJS({ 1: 'blah' })
-      const newRegion = selector.addAssetToRegion(region, assets)
-      expect(newRegion).to.equal(region)
-    })
-  })
-
   context('#selectPostAuthorId', () => {
     it('returns the post authorId', () => {
       const props = { postId: '666' }


### PR DESCRIPTION
Hoping by removing this being done at render time we see a small performance improvement.

Assets are still stored in the asset table, but the are also stored on the region itself in the same place the existing selector put them.