### PR TITLE
Assets: Fix split issue on Temp IDs

### DIFF
--- a/src/components/regions/ImageRegion.js
+++ b/src/components/regions/ImageRegion.js
@@ -64,7 +64,10 @@ const lightBoxImageStyle = css(
 
 // export to re-use this wonky image url parser
 export function getTempAssetId(url) {
-  return url.split('uploads/')[1].split('/ello-')[1].split('.')[0].replace(/-/g, '_')
+  if (url.includes('/ello-')) {
+    return url.split('uploads/')[1].split('/ello-')[1].split('.')[0].replace(/-/g, '_')
+  }
+  return null
 }
 
 class ImageRegion extends PureComponent {

--- a/src/components/regions/RegionRenderables.js
+++ b/src/components/regions/RegionRenderables.js
@@ -98,11 +98,9 @@ export class RegionItems extends PureComponent {
           let assetId = asset ? asset.get('id') : null
 
           // different treatment for brand new posts since `asset` does not exists in store yet
-          console.log(`assetId: ${assetId}`)
           if (!assetId) {
             const url = regionContent.get('url')
             if (url) {
-              console.log(`url: ${url}`)
               assetId = getTempAssetId(url)
             }
           }

--- a/src/components/regions/RegionRenderables.js
+++ b/src/components/regions/RegionRenderables.js
@@ -98,9 +98,11 @@ export class RegionItems extends PureComponent {
           let assetId = asset ? asset.get('id') : null
 
           // different treatment for brand new posts since `asset` does not exists in store yet
+          console.log(`assetId: ${assetId}`)
           if (!assetId) {
             const url = regionContent.get('url')
             if (url) {
+              console.log(`url: ${url}`)
               assetId = getTempAssetId(url)
             }
           }


### PR DESCRIPTION
Checks for the proper `/ello-` filename pattern before trying to generate a temp ID.