### PR TITLE
Don’t show auth promos where page promos are displayed

### DIFF
--- a/src/selectors/promotions.js
+++ b/src/selectors/promotions.js
@@ -34,12 +34,12 @@ export const selectIsCategoryPromotion = createSelector(
 
 export const selectLoggedInPagePromotions = createSelector(
   [selectPagePromotionals], promos =>
-    promos.filter(value => value.get('isLoggedIn') && !value.get('isArtistInvite') && !value.get('isEditorial')),
+    promos.filter(value => value.get('isLoggedIn') && !value.get('isArtistInvite') && !value.get('isEditorial') && !value.get('isAuthentication')),
 )
 
 export const selectLoggedOutPagePromotions = createSelector(
   [selectPagePromotionals], promos =>
-    promos.filter(value => !value.get('isLoggedIn') && !value.get('isArtistInvite') && !value.get('isEditorial')),
+    promos.filter(value => !value.get('isLoggedIn') && !value.get('isArtistInvite') && !value.get('isEditorial') && !value.get('isAuthentication')),
 )
 
 export const selectArtistInvitePagePromotions = createSelector(


### PR DESCRIPTION
- This is on our Categories V2 branch but since that isn’t merged yet, we
need to prevent the auth headers from being displayed.

https://www.pivotaltracker.com/story/show/155632616