### PR TITLE
Only render video if the original is a gif/mp4

### DIFF
--- a/src/components/assets/BackgroundImage.js
+++ b/src/components/assets/BackgroundImage.js
@@ -22,7 +22,7 @@ export function getSource(props) {
     return ''
   } else if (sources.getIn(['tmp', 'url'])) {
     return sources.getIn(['tmp', 'url'])
-  } else if (useGif && isGif(sources.getIn(['video', 'url']))) {
+  } else if (useGif && isGif(sources.getIn(['original', 'url'])) && sources.hasIn(['video', 'url'])) {
     return sources.getIn(['video', 'url'])
   } else if (useGif && isGif(sources.getIn(['original', 'url']))) {
     return sources.getIn(['original', 'url'])

--- a/test/unit/components/assets/BackgroundImage_test.js
+++ b/test/unit/components/assets/BackgroundImage_test.js
@@ -26,6 +26,22 @@ function gifCover() {
   })
 }
 
+function videoCover() {
+  return Immutable.fromJS({
+    original: { url: 'cover-original.gif', metadata: 'original' },
+    video: { url: 'cover-video.mp4', metadata: 'video' },
+  })
+}
+
+function buggedCover() {
+  return Immutable.fromJS({
+    optimized: { url: 'cover-optimized.jpg', metadata: 'optimized' },
+    original: { url: 'cover-original.jpg', metadata: 'original' },
+    xhdpi: { url: 'cover-xhdpi.gif', metadata: 'xhdpi' },
+    video: { url: 'cover-video.mp4', metadata: 'video' },
+  })
+}
+
 describe('BackgroundImage', () => {
   context('#getSource', () => {
     const props1 = { dpi: 'xhdpi', sources: null, useGif: false }
@@ -33,6 +49,8 @@ describe('BackgroundImage', () => {
     const props3 = { dpi: 'xhdpi', sources: gifCover(), useGif: true }
     const props4 = { dpi: 'xhdpi', sources: jpgCover(), useGif: true }
     const props5 = { dpi: 'optimized', sources: jpgCover(), useGif: false }
+    const props6 = { dpi: 'optimized', sources: videoCover(), useGif: true }
+    const props7 = { dpi: 'optimized', sources: buggedCover(), useGif: true }
 
     it('returns an empty string if the sources is null', () => {
       expect(getSource(props1)).to.equal('')
@@ -52,6 +70,14 @@ describe('BackgroundImage', () => {
 
     it('returns the large size when the size changes', () => {
       expect(getSource(props5)).to.equal('cover-optimized.jpg')
+    })
+
+    it('returns the video if available', () => {
+      expect(getSource(props6)).to.equal('cover-video.mp4')
+    })
+
+    it('does not return the video if original is not a gif/video', () => {
+      expect(getSource(props7)).to.equal('cover-optimized.jpg')
     })
   })
 })


### PR DESCRIPTION
- There is a bug in the API where if a user previously had a GIF as their
avatar and then uploaded an image, the video attribute in the metadata
doesn’t get erased. This helps with that by checking first if the original
is in fact a gif/mp4.

https://www.pivotaltracker.com/story/show/155664571