### PR TITLE
Fix DNT for logged in users.

### DIFF
--- a/src/containers/AnalyticsContainer.js
+++ b/src/containers/AnalyticsContainer.js
@@ -47,7 +47,7 @@ export function doesAllowTracking() {
 function mapStateToProps(state) {
   const creatorTypes = selectCreatorTypes(state)
   return {
-    allowsAnalytics: selectAllowsAnalytics(state),
+    allowsAnalytics: doesAllowTracking() && selectAllowsAnalytics(state),
     analyticsId: selectAnalyticsId(state),
     createdAt: selectCreatedAt(state),
     creatorTypes: creatorTypes.toArray(),


### PR DESCRIPTION
We were previously, in error, only respecting the DNT header if you were
logged out. For logged in users we were only using the Ello analytics
setting.

With this change we respect both the DNT header and the Ello setting. A
request not to be tracked by either will result in no tracking data.