### PR TITLE
Don't persist json in localstorage.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -76,7 +76,7 @@ const element = (
   </Provider>
 )
 
-const whitelist = ['authentication', 'editor', 'gui', 'json', 'profile']
+const whitelist = ['authentication', 'editor', 'gui', 'profile']
 
 // capture auth/gui so we can migrate to immutable
 // TODO: should probably be removed by 6/6/17


### PR DESCRIPTION
It is pretty easy to hit localstorage limits (2500kb in Safari) and
throw errors. If we don't persist our primary json store we won't hit
that issue.